### PR TITLE
Linux: XInitThreads before GTK init — fix intermittent X11 startup crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v0.3.2] — 2026-06-10
+
+### Fixed
+
+- **Linux: intermittent crash at launch.** WebKitGTK's internal threads talk
+  X11 directly; without Xlib's thread-safe mode they race the GTK main loop
+  and the app could abort during startup (`[xcb] Unknown sequence number
+  while awaiting reply`) or die silently with no window — roughly two out of
+  three launches in the CI smoke harness, timing-dependent on real desktops.
+  The app now calls `XInitThreads` before anything else on Linux. Wayland-only
+  systems without libX11 are unaffected (the call is skipped). Found by the
+  Linux smoke harness flaking on identical builds.
+
 ## [v0.3.1] — 2026-06-10
 
 The first release that arrives **as an in-app update** for v0.3.0 users — and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,11 @@ all; `scripts/release.sh` refuses to ship on mismatch. Don't bypass either.
 10. A transient zero-window moment must never exit the app — exit requests
     without a code are suppressed everywhere and Win/Linux quit-on-last-close
     is explicit in `windows::maybe_quit_after_close` (v0.1.1 bug).
+11. Linux `main()` calls `XInitThreads` (via x11-dl) as its FIRST statement,
+    before GTK/GDK touch X11. WebKitGTK's internal threads make direct X
+    calls; without thread-safe Xlib they intermittently corrupt the reply
+    stream at startup — `xcb_xlib_threads_sequence_lost` abort or a silent
+    exit(1) (v0.3.2 fix; ~2-in-3 startup crash under the CI smoke harness).
 
 ### Cross-compiling Windows locally (optional — CI does this natively)
 ```bash

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
  "tauri-plugin-updater",
  "ureq",
  "url",
+ "x11-dl",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,12 @@ url = "2"
 # tunnel.rs uses libc::kill for the SIGTERM→SIGKILL teardown on macOS AND Linux
 libc = "0.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# main.rs calls XInitThreads before GTK init (invariant #11) — WebKitGTK's
+# internal threads race Xlib otherwise (intermittent startup abort). dlopen
+# wrapper, so Wayland-only systems without libX11 degrade gracefully.
+x11-dl = "2"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
 objc2-app-kit = { version = "0.2", features = [

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -118,6 +118,19 @@ fn get_boot_info(app: tauri::AppHandle) -> serde_json::Value {
 }
 
 fn main() {
+    // Linux/X11: switch Xlib to thread-safe mode BEFORE any other X call in
+    // the process — must stay the first statement, ahead of GTK/GDK init.
+    // WebKitGTK's internal threads talk X11 directly; without this they race
+    // the main loop and intermittently corrupt Xlib's reply stream at startup
+    // ("[xcb] Unknown sequence number while awaiting reply …
+    // xcb_xlib_threads_sequence_lost" abort, or a silent fatal-IO exit(1) —
+    // 5 of 7 Linux smoke runs on identical code). dlopen via x11-dl so
+    // Wayland-only systems without libX11 simply skip it.
+    #[cfg(target_os = "linux")]
+    if let Ok(xlib) = x11_dl::xlib::Xlib::open() {
+        unsafe { (xlib.XInitThreads)() };
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             // Second launch (e.g. double-opening the .app/.exe): focus the


### PR DESCRIPTION
## Symptom

The Linux smoke harness failed on **5 of 7 runs of identical app code** (everything after the D17 fix), while the same binary passed twice — including v0.3.1's release run. Two failure shapes, one cause:

- `[xcb] Unknown sequence number while awaiting reply … Assertion '!xcb_xlib_threads_sequence_lost' failed` → SIGABRT
- silent death with exit code 1 (Xlib's default fatal-IO handler calls `exit(1)`)

## Root cause

WebKitGTK's internal threads make direct X11 calls. Xlib is not thread-safe unless `XInitThreads()` is called **before any other Xlib call in the process** — and nothing in our stack (GTK3, tao's gtk backend, this WebKitGTK build) does it for us. Concurrent X traffic from WebKit's threads vs the GTK main loop intermittently corrupts Xlib's reply sequence state at startup. Timing-dependent: CI under Xvfb amplifies it, but a real X11 desktop can hit it.

## Fix

`XInitThreads` via `x11-dl` (dlopen, so Wayland-only systems without libX11 gracefully skip) as the **first statement of `main`**, ahead of GTK/GDK display open. Codified as CLAUDE.md invariant #11.

## Validation

- `cargo fmt` / `clippy -D warnings` / `cargo test` clean (macOS)
- `cargo xwin check` clean (Windows target unaffected — dep and code are Linux-only)
- Linux Smoke dispatched repeatedly on this branch — results posted below before merge. Prior baseline: ~30% pass rate; bar: 5/5 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)