### PR TITLE
macOS: fix every-time freeze on Cmd+T — defer addTabbedWindow via GCD main queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v0.3.3] — 2026-06-10
+
+### Fixed
+
+- **macOS: app froze ("crashed") every time a new tab was opened.** Cmd+T
+  built the window fine, but the native tab attach (`addTabbedWindow`) ran
+  inside the event loop's dispatch, where AppKit may force the other tab's
+  window to redraw *synchronously* — and that redraw re-enters the windowing
+  layer's non-reentrant lock, deadlocking the main thread on itself. The app
+  froze instantly and forever (no crash report — it never crashes, it hangs;
+  confirmed by macOS hang diagnostics on v0.3.1 and v0.3.2). The freeze only
+  triggers when the two windows' sizes differ, which is why default-size dev
+  windows masked it and real resized windows hit it 100% of the time. Tab
+  attach (and the Cmd+N tabbing-mode dance) now runs via the GCD main queue —
+  outside the event dispatch — and Cmd+T/Cmd+N window creation runs inline on
+  the main thread on macOS, like the original prototype. Verified live: tab
+  attach plus continued main-thread heartbeats on the previously-freezing
+  setup.
+
 ## [v0.3.2] — 2026-06-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,12 +95,13 @@ all; `scripts/release.sh` refuses to ship on mismatch. Don't bypass either.
 7. Injected scripts (`bridge.rs`) only get `core:event:default` capability in remote
    content — never grant the remote origin command access.
 8. Windows ssh spawns need `CREATE_NO_WINDOW` or a console flashes per reconnect.
-9. **Never create a webview window synchronously inside an IPC command or
-   event handler.** On Windows, WebView2 init needs the main message loop
+9. **Windows/Linux: never create a webview window synchronously inside an IPC
+   command or event handler.** WebView2 init needs the main message loop
    pumping — a webview built from a blocking main-thread context stalls forever
    and the window never paints (v0.1.2 bug). Build windows from a worker thread
-   (the orchestrator pattern); window creation from background threads is safe
-   in Tauri on all three platforms.
+   (the orchestrator pattern). macOS is the deliberate exception: menu-driven
+   window creation runs INLINE on the main thread (`conn::open_new_session`) —
+   plain AppKit usage, no WebView2 constraint.
 10. A transient zero-window moment must never exit the app — exit requests
     without a code are suppressed everywhere and Win/Linux quit-on-last-close
     is explicit in `windows::maybe_quit_after_close` (v0.1.1 bug).
@@ -109,6 +110,16 @@ all; `scripts/release.sh` refuses to ship on mismatch. Don't bypass either.
     calls; without thread-safe Xlib they intermittently corrupt the reply
     stream at startup — `xcb_xlib_threads_sequence_lost` abort or a silent
     exit(1) (v0.3.2 fix; ~2-in-3 startup crash under the CI smoke harness).
+12. **macOS NSWindow mutations that can force a synchronous display
+    (`addTabbedWindow`, `setTabbingMode`) go through the GCD main queue
+    (`macos::dispatch_main_async`) — NEVER directly inside a tao callout**
+    (menu/IPC handlers, `run_on_main_thread` closures). AppKit's forced
+    redraw re-enters tao's `draw_rect`, which takes tao's non-reentrant
+    handler mutex → main-thread self-deadlock, app frozen with no crash
+    report (the v0.2.0–v0.3.2 every-Cmd+T freeze; size-dependent, so
+    default-size dev windows masked it). Repro/guard: run with
+    `HERMES_TEST_TAB_AFTER=<s>` — drives the Cmd+T path and heartbeats the
+    main thread.
 
 ### Cross-compiling Windows locally (optional — CI does this natively)
 ```bash

--- a/src-tauri/src/conn.rs
+++ b/src-tauri/src/conn.rs
@@ -217,13 +217,20 @@ fn start_recovery_loop(app: &AppHandle, target: String) {
 }
 
 /// Guarded entry for New Window / New Tab (port of openNewBrowserSession).
-/// Runs on a worker thread: window creation must never happen synchronously
-/// on the main thread inside a command/event handler — on Windows that
-/// stalls WebView2 initialization and the window never paints (same bug
-/// class as the v0.1.1 prefs-window report).
+///
+/// Threading is platform-split:
+/// - Windows/Linux: a worker thread — WebView2 stalls forever when a webview
+///   is created synchronously inside a main-thread command/event handler
+///   (v0.1.2 bug, CLAUDE.md invariant #9).
+/// - macOS: INLINE on the calling (main) thread — menu/Dock handlers already
+///   run there, window creation on main is plain AppKit usage, and it avoids
+///   pointless worker→main blocking round-trips. NOTE the actual Cmd+T
+///   freeze fix lives in macos::add_tabbed_window (GCD main-queue deferral,
+///   CLAUDE.md invariant #12) — tab attach must run outside tao's event
+///   dispatch no matter which thread builds the window.
 pub fn open_new_session(app: &AppHandle, as_tab: bool) {
     let app = app.clone();
-    std::thread::spawn(move || {
+    let work = move || {
         let p = prefs::load(&app);
         if p.connection_mode == "ssh"
             && tunnel::current_status(&app) != crate::state::TunnelStatus::Connected
@@ -242,5 +249,9 @@ pub fn open_new_session(app: &AppHandle, as_tab: bool) {
             }
         }
         windows::open_browser(&app, &p, as_tab);
-    });
+    };
+    #[cfg(target_os = "macos")]
+    work();
+    #[cfg(not(target_os = "macos"))]
+    std::thread::spawn(work);
 }

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -17,13 +17,53 @@ use objc2::runtime::AnyClass;
 use objc2::ClassType;
 use objc2_app_kit::{NSView, NSWindow, NSWindowOrderingMode, NSWindowTabbingMode};
 use objc2_foundation::{CGPoint, CGRect, CGSize};
+use std::ffi::c_void;
 use tauri::WebviewWindow;
+
+// ---- GCD main-queue dispatch ----
+//
+// NSWindow mutations that can force a synchronous display (addTabbedWindow,
+// tabbingMode) must run OUTSIDE any tao event-handler frame. Inside one
+// (menu/IPC handlers, run_on_main_thread closures), tao holds its
+// non-reentrant Handler mutex; AppKit's forced redraw re-enters
+// tao::view::draw_rect → handle_nonuser_event → the SAME mutex →
+// self-deadlock on the main thread (the v0.2.0–v0.3.2 frozen-app-on-Cmd+T
+// bug; conditional on the tab windows needing a resize, which is why
+// default-size dev windows never hit it). The GCD main queue is drained by
+// the runloop between tao callouts, so a block queued here runs with the
+// handler mutex free.
+#[repr(C)]
+struct DispatchObject {
+    _private: [u8; 0],
+}
+extern "C" {
+    static _dispatch_main_q: DispatchObject;
+    fn dispatch_async_f(
+        queue: *const DispatchObject,
+        context: *mut c_void,
+        work: extern "C" fn(*mut c_void),
+    );
+}
+extern "C" fn dispatch_trampoline(ctx: *mut c_void) {
+    let f = unsafe { Box::from_raw(ctx as *mut Box<dyn FnOnce()>) };
+    f();
+}
+fn dispatch_main_async(f: impl FnOnce() + Send + 'static) {
+    let boxed: Box<Box<dyn FnOnce()>> = Box::new(Box::new(f));
+    unsafe {
+        dispatch_async_f(
+            &_dispatch_main_q,
+            Box::into_raw(boxed) as *mut c_void,
+            dispatch_trampoline,
+        )
+    };
+}
 
 /// Attach `new_win` to `host`'s native tab group (Cmd+T behavior).
 pub fn add_tabbed_window(host: &WebviewWindow, new_win: &WebviewWindow) {
     let host2 = host.clone();
     let new_win = new_win.clone();
-    let result = host.run_on_main_thread(move || {
+    dispatch_main_async(move || {
         let (Ok(host_ptr), Ok(new_ptr)) = (host2.ns_window(), new_win.ns_window()) else {
             return;
         };
@@ -32,17 +72,15 @@ pub fn add_tabbed_window(host: &WebviewWindow, new_win: &WebviewWindow) {
             let new_ns: &NSWindow = &*(new_ptr as *const NSWindow);
             host_ns.addTabbedWindow_ordered(new_ns, NSWindowOrderingMode::NSWindowAbove);
         }
+        log::info!("macos: tabbed {} into {}", new_win.label(), host2.label());
     });
-    if let Err(e) = result {
-        log::warn!("macos: addTabbedWindow dispatch failed: {e}");
-    }
 }
 
 /// Set NSWindow.tabbingMode. `disallowed=true` before showing a Cmd+N window
 /// keeps it standalone; restore preferred afterwards (Swift fix).
 pub fn set_tabbing_mode(window: &WebviewWindow, disallowed: bool) {
     let w = window.clone();
-    let _ = window.run_on_main_thread(move || {
+    dispatch_main_async(move || {
         if let Ok(ptr) = w.ns_window() {
             unsafe {
                 let ns: &NSWindow = &*(ptr as *const NSWindow);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -202,6 +202,33 @@ fn main() {
                 }
             }
             conn::reconnect(&handle);
+            // Test hook: drive the Cmd+T path without UI scripting, then
+            // heartbeat the main thread — used by the macOS tab-deadlock
+            // repro and (later) the Linux smoke multi-tab exercise. Inert
+            // unless HERMES_TEST_TAB_AFTER=<seconds> is set.
+            if let Ok(v) = std::env::var("HERMES_TEST_TAB_AFTER") {
+                if let Ok(secs) = v.parse::<u64>() {
+                    let h = handle.clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_secs(secs));
+                        let h2 = h.clone();
+                        let _ = h.run_on_main_thread(move || {
+                            conn::open_new_session(&h2, true);
+                            log::info!("test: tab hook dispatched on main");
+                        });
+                        for i in 1..=8u32 {
+                            std::thread::sleep(std::time::Duration::from_secs(2));
+                            let h3 = h.clone();
+                            let _ = h.run_on_main_thread(move || {
+                                log::info!(
+                                    "test: heartbeat {i} windows={}",
+                                    windows::content_window_handles(&h3).len()
+                                );
+                            });
+                        }
+                    });
+                }
+            }
             // Passive update check shortly after launch (Sparkle parity) —
             // never blocks startup; only surfaces a dialog when an update
             // actually exists.


### PR DESCRIPTION
## Symptom

Maintainer report: opening a new tab on macOS "crashes every single time" on the latest version. No crash reports exist — because nothing crashes: **the main thread deadlocks** and the app freezes until force-quit. macOS wrote `.hang` diagnostics for v0.3.1 and v0.3.2, both showing the identical deadlocked stack. Affects every CI build since v0.2.0.

## Root cause

Production hang reports + a fully-symbolicated live `sample` of a debug repro:

```
tao Handler::handle_user_events            ← holds tao's non-reentrant Handler mutex
  → addTabbedWindow_ordered
    → AppKit _syncInactiveTabWindowSizesToWindow:
      → CA::Transaction::commit → NSViewBackingLayer display   (SYNCHRONOUS)
        → tao::view::draw_rect
          → Handler::handle_nonuser_event
            → Mutex::lock                  ← same mutex → self-deadlock
```

`addTabbedWindow` ran inside a tao event-handler callout. AppKit may synchronously force the *other* tab window to redraw during the attach (it resizes inactive tabs to match); that redraw re-enters tao's `draw_rect`, which needs the same non-reentrant lock the thread already holds. **Conditional on the two windows' sizes differing** — default-size dev windows masked it (why prototype tabs worked), any user-resized window hits it 100%.

## Fix

- `macos::add_tabbed_window` / `set_tabbing_mode` now dispatch via the **GCD main queue** (raw `dispatch_async_f`, zero new dependencies). The runloop drains GCD blocks *outside* tao callouts, so the handler mutex is free when AppKit forces the redraw.
- Cmd+T/Cmd+N creation runs **inline on the main thread** on macOS (the worker thread bought nothing; invariant #9 narrowed to Windows/Linux where WebView2 requires it).
- New invariant #12 + env-gated repro hook `HERMES_TEST_TAB_AFTER=<s>` (drives the exact Cmd+T path, then heartbeats the main thread).

## Validation

- **Pre-fix** (maintainer's machine, where it reproduced 100%): heartbeats stop dead at the attach; live sample shows the stack above, 917/917 samples.
- **Post-fix**: `macos: tabbed main-2 into main-1` + all 8 heartbeats land with `windows=2`, app responsive throughout.
- `cargo fmt` / `clippy -D warnings` / `cargo test` clean; `cargo xwin check` clean (Windows path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)