### PR TITLE
Fix links not opening in browser (#12) and new-tab white flash (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v0.3.4]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Clicking a link in chat did nothing instead of opening the browser.**
+  The WebUI renders chat links with `target="_blank"`, and our injected script
+  forwarded those clicks to native by emitting an `open-external` IPC event.
+  That emit posts to `ipc.localhost`, which the remote page's own CSP
+  `connect-src` blocks (the WebUI server governs the page's CSP, not the shell),
+  so the event never reached Rust and the click was a no-op. External links
+  (and `window.open`) now navigate the top frame instead: the native
+  `on_navigation` hook — which is not subject to the page CSP — opens external
+  hosts in the system browser and cancels the navigation so the page stays put,
+  exactly as plain links already did. No server-side change required.
+  (#12, reported by Deor; cross-ref hermes-webui#4040.)
+- **White flash when opening a new tab (Windows/Linux).** A new tab is a child
+  webview added to an already-visible window, so it painted white until its
+  first paint — the window-level anti-flash (build hidden, reveal on load)
+  couldn't cover it. New tab webviews now get an opaque native background in the
+  cached theme color, so they come up theme-colored instead of white. (#4,
+  reported by Rod.)
+
 ## [v0.3.3] — 2026-06-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ state; the shell owns the window, the ssh process, and a small prefs JSON.
 ## Repo structure
 
 ```
-src/                      # shell pages (vanilla): splash.html, error.html, prefs.html
+src/                      # shell pages (vanilla): splash.html, error.html, prefs.html,
+                          #   index.html, shell.html (Win/Linux tab-strip shell) + shared/
+                          #   (shell.css, shell.js)
 src-tauri/src/
   main.rs                 # tauri Builder, plugins, commands, window/menu events
   conn.rs                 # connection orchestrator (splash → connect → windows | error)
@@ -42,6 +44,14 @@ src-tauri/src/
   theme.rs                # CSS color parse / luminance / hex (pure fns, unit-tested)
   paste.rs                # clipboard image → PNG → base64 → 3-strategy injection
   menu.rs                 # macOS menu bar (Win/Linux use the injected shortcut forwarder)
+  state.rs                # shared AppState: TunnelStatus, per-window TabEntry/WindowTabs,
+                          #   ssh Child handles, atomics (mirrors Swift TunnelManager enum)
+  strip.rs                # Win/Linux tab strip: 38px shell.html webview + one live
+                          #   content webview per tab; hidden tabs stay alive (SSE/draft
+                          #   survival). HERMES_FORCE_STRIP=1 exercises it on macOS
+  updater.rs              # auto-update (Sparkle parity): minisign-verified vs pubkey in
+                          #   tauri.conf.json, latest.json manifest; passive + interactive
+                          #   check. Win NSIS/MSI, mac .app, Linux AppImage (.deb degrades)
 src-tauri/capabilities/   # IPC scoping: full for shell pages; remote content may ONLY
                           #   emit events (content.json)
 ```

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -222,20 +222,31 @@ const NOTIFY_WATCHER: &str = r##"
 /// (the WebUI server, not the shell, governs CSP because `app.security.csp` is
 /// null) — so the emit silently fails and the click is a no-op (issue #12,
 /// hermes-webui#4040). `on_navigation` is a native wry hook, not subject to CSP.
+///
+/// Only http(s) URLs are routed through the top-frame navigation:
+/// `navigation_allowed` deliberately lets non-web schemes through (the engine
+/// needs them internally), so navigating to `about:blank`/`blob:`/`javascript:`
+/// here would REPLACE the app's top frame (a common `window.open` pattern in
+/// libraries). Non-http(s) window.open calls are dropped (the old EMIT path's
+/// effective behavior); non-http(s) `_blank` anchors keep their default action
+/// so the download bridge / engine still handle them.
 const WINDOW_OPEN: &str = r##"
   (function () {
     window.open = function (u) {
       if (!u) return null;
-      location.href = String(u);
+      try {
+        var x = new URL(String(u), location.href);
+        if (x.protocol === 'http:' || x.protocol === 'https:') location.href = x.href;
+      } catch (e) {}
       return null;
     };
     document.addEventListener('click', function (e) {
       var a = e.target && e.target.closest ? e.target.closest('a[target="_blank"]') : null;
-      if (a && a.href) {
-        e.preventDefault();
-        e.stopPropagation();
-        location.href = a.href;
-      }
+      if (!a || !a.href) return;
+      if (a.protocol !== 'http:' && a.protocol !== 'https:') return;
+      e.preventDefault();
+      e.stopPropagation();
+      location.href = a.href;
     }, true);
   })();
 "##;

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -212,20 +212,21 @@ const NOTIFY_WATCHER: &str = r##"
 
 /// S11 — window.open / target=_blank: same-origin navigates, external opens
 /// in the system browser (parity-plus; the Swift app drops these silently).
+///
+/// Both cases route through a top-frame navigation rather than the IPC
+/// `open-external` emit. The native `on_navigation` hook
+/// (`windows::navigation_allowed`) lets same-origin/localhost through and opens
+/// external hosts in the system browser, cancelling the navigation so the page
+/// stays put. We deliberately avoid `EMIT('open-external', …)` here: that posts
+/// to `ipc.localhost`, which the remote page's own CSP `connect-src` blocks
+/// (the WebUI server, not the shell, governs CSP because `app.security.csp` is
+/// null) — so the emit silently fails and the click is a no-op (issue #12,
+/// hermes-webui#4040). `on_navigation` is a native wry hook, not subject to CSP.
 const WINDOW_OPEN: &str = r##"
   (function () {
-    const isLocal = function (u) {
-      try {
-        const x = new URL(u, location.href);
-        if (x.origin === location.origin) return true;
-        const h = x.hostname.replace(/^\[|\]$/g, '');
-        return h === 'localhost' || h === '127.0.0.1' || h === '::1';
-      } catch (e) { return false; }
-    };
     window.open = function (u) {
       if (!u) return null;
-      if (isLocal(u)) location.href = u;
-      else EMIT('open-external', String(u));
+      location.href = String(u);
       return null;
     };
     document.addEventListener('click', function (e) {
@@ -233,8 +234,7 @@ const WINDOW_OPEN: &str = r##"
       if (a && a.href) {
         e.preventDefault();
         e.stopPropagation();
-        if (isLocal(a.href)) location.href = a.href;
-        else EMIT('open-external', a.href);
+        location.href = a.href;
       }
     }, true);
   })();

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -12,7 +12,7 @@ use crate::state::{AppState, TabEntry, WindowTabs};
 use crate::{bridge, prefs, tunnel, windows};
 use serde_json::json;
 use std::sync::atomic::Ordering;
-use tauri::webview::WebviewBuilder;
+use tauri::webview::{Color, WebviewBuilder};
 use tauri::window::WindowBuilder;
 use tauri::{
     AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Webview, WebviewUrl, Window, Wry,
@@ -191,12 +191,21 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
 
     let (r, g, b) = prefs::pre_paint_color(app);
     let hex = crate::theme::hex_string(r, g, b);
+    // Paint the native webview surface in the cached theme color so a freshly
+    // added tab never flashes white before its first paint. The window-level
+    // anti-flash (build-hidden → reveal on load) can't help here: a new tab is
+    // a child webview of an already-visible window, so it shows immediately
+    // (issue #4). On Windows the alpha is ignored and the color renders opaque,
+    // which is what we want.
+    let to8 = |v: f64| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+    let bg = Color(to8(r), to8(g), to8(b), 255);
     // No injected ssh footer in strip mode — status lives in the strip.
     let init = bridge::init_script(&tab_label, &hex, false);
 
     let nav_app = app.clone();
     let load_window = window_label.to_string();
     let wb = WebviewBuilder::new(&tab_label, WebviewUrl::External(target))
+        .background_color(bg)
         .initialization_script(&init)
         .on_navigation(move |url| {
             windows::navigation_allowed(&nav_app, url, allowed_host.as_deref())

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -195,7 +195,7 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
     // added tab never flashes white before its first paint. The window-level
     // anti-flash (build-hidden → reveal on load) can't help here: a new tab is
     // a child webview of an already-visible window, so it shows immediately
-    // (issue #4). On Windows the alpha is ignored and the color renders opaque,
+    // (issue #4). On Windows wry clamps any non-zero alpha to fully opaque,
     // which is what we want.
     let to8 = |v: f64| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
     let bg = Color(to8(r), to8(g), to8(b), 255);


### PR DESCRIPTION
Two low-risk, no-brainer fixes from the open issue tracker.

## #12 — Clicking a link in chat did nothing (should open the browser)

**Symptom:** clicking a `https://` link in chat is a no-op.

**Root cause:** the WebUI renders chat links with `target="_blank"`. The injected `WINDOW_OPEN` script intercepted those clicks and forwarded the URL to native via `EMIT('open-external', href)`. That emit is a Tauri IPC POST to `ipc.localhost`, but the remote page's CSP `connect-src` (governed by the WebUI server, since `app.security.csp` is null) does not whitelist `ipc.localhost` — so the event never reached Rust and the click did nothing. Confirmed by a tester's server log showing `blockedURL: http://ipc.localhost/plugin%3Aevent%7Cemit`.

**Fix:** external links and `window.open` now navigate the top frame (`location.href = …`) instead of emitting. The native `on_navigation` hook (`windows::navigation_allowed`) — which is **not** subject to the page CSP — opens external hosts in the system browser and cancels the navigation so the page stays put. This is the exact path plain (non-`target="_blank"`) external links already used, so it's proven on all three platforms. No server-side change required (the WebUI-side CSP allowance in hermes-webui#4040 is no longer a prerequisite for links to work here).

`bridge.rs` `WINDOW_OPEN`. The now-unused `open-external` Rust handler is left in place as a harmless defensive fallback.

## #4 — White flash when opening a new tab (Windows/Linux)

**Symptom:** opening a new tab shows a brief white flash before the page paints ("hurts the eyes a bit").

**Root cause:** a new tab is a child webview added to an **already-visible** window, so it paints white until first paint. The window-level anti-flash (build hidden → reveal on `PageLoadEvent::Finished`) can't cover a child webview of a live window.

**Fix:** new tab webviews get an opaque native background in the cached theme color (`WebviewBuilder::background_color`), so they come up theme-colored instead of white. On Windows the alpha is ignored and the color renders opaque, which is what we want. macOS uses native tabs (not the strip), so it's unaffected.

`strip.rs` `add_tab`.

## Testing
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green locally.
- #12 reasoned against the existing, proven `navigation_allowed` external-open path; #4 is an additive native background hint with no behavior change.

## Not included (deliberately deferred — not no-brainers)
- **#3** multi-tab profile/cookie isolation — needs per-tab webview data partitioning and possibly WebUI coordination.
- **#5** icon white fringe — uncertain root cause; needs icon-asset regeneration + visual verification.
- **#6** in-app version / what's new — the version is already shown (macOS app menu and strip ⋯ menu); only the post-update "what's new" remains, which is larger.

Closes #12
Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)