### PR TITLE
Fix Windows/Linux tabs stuck on "New Tab": source titles natively (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [v0.3.5]
+
+### Fixed
+
+- **Windows/Linux: tabs were stuck on "New Tab" and never showed the active
+  session (and titles could "reset" to `Hermes WebUI ● <host>`).** The custom
+  tab strip derived each tab's title from an injected script that posted the
+  page's `document.title` back over the JS event IPC (`window.__TAURI__`). That
+  IPC isn't reliably available in remote-origin content webviews, so the title
+  report silently no-op'd and the tab kept its placeholder. Titles are now read
+  from the webview engine directly via a native title-changed hook
+  (WebView2/WebKitGTK/WKWebView), independent of page JS, the IPC global, and
+  the page's CSP — the same "don't depend on the remote webview's IPC" approach
+  the link-opening fix used. (#15, reported by Deor and b3nw.)
+- **A transient blank title no longer wipes a good tab title.** While a tab is
+  mid-load (or briefly reports a separator-only title), the strip used to fall
+  back to the `Hermes WebUI ● <host>` placeholder. A known-good title (or the
+  initial "New Tab" seed) is now kept until a real title arrives.
+- **Tab titles now strip the trailing name suffix for custom bot names and
+  non-default profiles.** The WebUI appends a " — name" suffix where the name is
+  the configured bot name or the profile name — not always "Hermes". The suffix
+  is now removed generically (only the last separator-delimited segment, so an
+  em-dash inside the session title itself is preserved) instead of matching the
+  literal "Hermes".
+- **Direct-mode connections to a non-localhost HTTP server now get the bridge
+  again.** The content-webview capability listed `https://*` but no plain
+  `http://*`, so for a Direct connection to e.g. `http://192.168.x.x:8787`
+  every bridge emit (theme sync, the "response is ready" notification) was
+  silently dropped. Plain-HTTP remote origins are now covered (still
+  event-emit-only — no command access).
+
 ## [v0.3.4] — 2026-06-12
 
 ### Fixed

--- a/src-tauri/capabilities/content.json
+++ b/src-tauri/capabilities/content.json
@@ -10,6 +10,8 @@
       "http://localhost:*",
       "http://127.0.0.1",
       "http://127.0.0.1:*",
+      "http://*",
+      "http://*:*",
       "https://*",
       "https://*:*"
     ]

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -251,25 +251,6 @@ const WINDOW_OPEN: &str = r##"
   })();
 "##;
 
-/// Title watcher — feeds the native tab/window title pipeline.
-const TITLE_WATCHER: &str = r##"
-  (function () {
-    let last = null;
-    const report = function () {
-      const t = document.title || '';
-      if (t !== last) { last = t; EMIT('title', t); }
-    };
-    const start = function () {
-      report();
-      const el = document.querySelector('title');
-      if (el) new MutationObserver(report).observe(el, { childList: true, characterData: true, subtree: true });
-      setInterval(report, 2000);
-    };
-    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start);
-    else start();
-  })();
-"##;
-
 /// SSH footer — 28px status bar pinned to the bottom, tinted with the exact
 /// page background (Swift parity: the footer is the only chrome painted with
 /// the page RGB). Injected only in ssh-mode windows. The native side drives
@@ -445,7 +426,6 @@ pub fn init_script(label: &str, pre_paint_hex: &str, is_ssh: bool) -> String {
     parts.push(THEME_BRIDGE);
     parts.push(NOTIFY_WATCHER);
     parts.push(WINDOW_OPEN);
-    parts.push(TITLE_WATCHER);
     parts.push(FIND_BAR);
     if cfg!(any(target_os = "macos", target_os = "linux")) {
         parts.push(DOWNLOAD_BRIDGE);
@@ -481,16 +461,10 @@ pub fn install(app: &AppHandle) {
         let label = payload["label"].as_str().unwrap_or("").to_string();
         let kind = payload["kind"].as_str().unwrap_or("");
         match kind {
-            "title" => {
-                let raw = payload["value"].as_str().unwrap_or("").to_string();
-                if label.starts_with("tab-") {
-                    crate::strip::set_tab_title(&handle, &label, &raw);
-                } else {
-                    let state = handle.state::<AppState>();
-                    state.raw_titles.lock().unwrap().insert(label.clone(), raw);
-                    windows::refresh_title(&handle, &label);
-                }
-            }
+            // NOTE: titles no longer arrive via this bridge — they're sourced
+            // natively through wry's on_document_title_changed hook (see
+            // windows::apply_reported_title), which works even when the
+            // remote-webview IPC that powers EMIT() is unavailable (issue #15).
             "theme" => {
                 if let Some(css) = payload["value"].as_str() {
                     handle_theme_report(&handle, css);

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -210,6 +210,12 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
         .on_navigation(move |url| {
             windows::navigation_allowed(&nav_app, url, allowed_host.as_deref())
         })
+        // Native title source — replaces the JS EMIT('title') watcher, which
+        // silently no-ops in remote-origin tab webviews (issue #15). The
+        // webview's label IS the tab label.
+        .on_document_title_changed(|wv, title| {
+            windows::apply_reported_title(wv.app_handle(), wv.label(), &title);
+        })
         .on_page_load(move |webview, payload| {
             if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
                 return;

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -166,6 +166,11 @@ pub fn open_browser(app: &AppHandle, p: &prefs::Prefs, as_tab: bool) -> Option<W
         .visible(false)
         .initialization_script(&init)
         .on_navigation(move |url| navigation_allowed(&nav_app, url, allowed_host.as_deref()))
+        // Native title source (see apply_reported_title) — replaces the JS
+        // EMIT('title') watcher so titles work regardless of remote-webview IPC.
+        .on_document_title_changed(|win, title| {
+            apply_reported_title(win.app_handle(), win.label(), &title);
+        })
         .on_page_load(move |webview, payload| {
             if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
                 return;
@@ -375,10 +380,35 @@ fn push_tunnel_status(
     ));
 }
 
+/// Strip the WebUI's trailing " — <name>" suffix from a reported document
+/// title. The suffix is NOT always "Hermes": it's the user's configured bot
+/// name, or — on a non-default profile — the capitalized profile name (issue
+/// #15). So we strip the trailing `<sep> <segment>` generically rather than
+/// matching the literal "Hermes". `<segment>` is separator-free, so only the
+/// LAST separator group is removed — an internal " — " in the session title
+/// itself is preserved ("Plan A — Phase 1 — Hermes" → "Plan A — Phase 1").
+/// Returns empty when the title is empty or separator/suffix-only.
+pub fn clean_title(raw: &str) -> String {
+    // Leading `\s*` (not `\s+`) so a session-less title like " — Hermes" (which
+    // trims to "— Hermes", separator at index 0) still strips to empty.
+    let re = regex::Regex::new(r"\s*[—–\-|·]\s+[^—–\-|·]+\s*$").unwrap();
+    let stripped = re.replace(raw.trim(), "").trim().to_string();
+    // A remainder that is only separators/whitespace (e.g. a bare "—") is a
+    // transient state, not a real session title — collapse it to empty so the
+    // caller's guard treats it as "no title". Real titles always contain a
+    // non-separator character.
+    if stripped
+        .chars()
+        .all(|c| c.is_whitespace() || "—–-|·".contains(c))
+    {
+        return String::new();
+    }
+    stripped
+}
+
 /// Title pipeline — port of refreshTabTitle (docs/03 § Windows & tabs).
 pub fn display_title(raw: &str, mode: &str, target: &str, healthy: bool) -> String {
-    let re = regex::Regex::new(r"\s+[—\-|·]\s+Hermes(\s+Agent)?\s*$").unwrap();
-    let stripped = re.replace(raw.trim(), "").trim().to_string();
+    let stripped = clean_title(raw);
     if !stripped.is_empty() {
         if stripped.chars().count() > 40 {
             let head: String = stripped.chars().take(38).collect();
@@ -425,6 +455,34 @@ pub fn refresh_title(app: &AppHandle, label: &str) {
     let healthy = state.healthy.load(Ordering::SeqCst);
     let target = prefs::load(app).target_url;
     let _ = w.set_title(&display_title(&raw, &mode, &target, healthy));
+}
+
+/// A content webview reported a new `document.title` via wry's native
+/// title-changed hook (`on_document_title_changed`). This is the sole title
+/// source — it replaces the old injected `EMIT('title')` watcher, which
+/// silently no-ops whenever `window.__TAURI__`/the event IPC isn't available in
+/// a remote-origin webview (issue #15, failure mode #1: tabs stuck on "New
+/// Tab"). Being a native callback, it is immune to that and to the page CSP.
+///
+/// Transient empty/separator-only reports are ignored so a known-good title is
+/// never downgraded to the host fallback (`display_title`'s empty-strip branch)
+/// — issue #15 failure mode #2 ("title instantly resets to Hermes WebUI ●
+/// host"). The 38px strip seed ("New Tab") likewise survives until a real title
+/// arrives.
+pub fn apply_reported_title(app: &AppHandle, label: &str, raw: &str) {
+    if clean_title(raw).is_empty() {
+        return;
+    }
+    if label.starts_with("tab-") {
+        strip::set_tab_title(app, label, raw);
+    } else {
+        app.state::<AppState>()
+            .raw_titles
+            .lock()
+            .unwrap()
+            .insert(label.to_string(), raw.to_string());
+        refresh_title(app, label);
+    }
 }
 
 pub fn refresh_all_titles(app: &AppHandle) {
@@ -611,7 +669,7 @@ pub fn open_prefs(app: &AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::display_title;
+    use super::{clean_title, display_title};
 
     #[test]
     fn strips_hermes_suffix_and_truncates() {
@@ -631,6 +689,48 @@ mod tests {
         let long = format!("{} — Hermes", "x".repeat(60));
         let t = display_title(&long, "ssh", "http://localhost:8787", true);
         assert_eq!(t.chars().count(), 39); // 38 + ellipsis
+    }
+
+    #[test]
+    fn strips_non_hermes_suffix() {
+        // The WebUI appends the configured bot name or the profile name, not
+        // always "Hermes" (issue #15). The strip must be generic.
+        assert_eq!(
+            display_title(
+                "Daily standup — Claude",
+                "ssh",
+                "http://localhost:8787",
+                true
+            ),
+            "Daily standup"
+        );
+        assert_eq!(
+            display_title("Budget review — Work", "ssh", "http://localhost:8787", true),
+            "Budget review"
+        );
+        // Only the LAST separator group is removed — an internal em-dash in the
+        // session title itself survives.
+        assert_eq!(
+            display_title(
+                "Plan A — Phase 1 — Hermes",
+                "ssh",
+                "http://localhost:8787",
+                true
+            ),
+            "Plan A — Phase 1"
+        );
+    }
+
+    #[test]
+    fn clean_title_empty_for_transient_states() {
+        // These are the reports the title hook must NOT promote to a tab title;
+        // apply_reported_title drops them so a good title isn't downgraded to
+        // the host fallback (issue #15 failure mode #2).
+        assert_eq!(clean_title(""), "");
+        assert_eq!(clean_title("   "), "");
+        assert_eq!(clean_title(" — Hermes"), "");
+        // A bare title with no separator suffix is meaningful, not transient.
+        assert_eq!(clean_title("Hermes"), "Hermes");
     }
 
     #[test]

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -4,7 +4,22 @@
 use crate::state::{AppState, TunnelStatus};
 use crate::{bridge, prefs, strip, theme};
 use std::sync::atomic::Ordering;
+use std::sync::LazyLock;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+
+/// Title-segment separators the WebUI may place before its trailing name
+/// suffix. Shared by the suffix regex and the separator-only collapse check in
+/// `clean_title` so the two can't drift. The hyphen is last so it reads as a
+/// literal inside the regex character classes built below.
+const TITLE_SEPARATORS: &str = "—–|·-";
+
+/// Matches a trailing ` <sep> <segment>` suffix (segment is separator-free, so
+/// only the LAST separator group is removed). Leading `\s*` (not `\s+`) so a
+/// session-less title like " — Hermes" (trims to "— Hermes", separator at
+/// index 0) still strips to empty. Compiled once.
+static TITLE_SUFFIX_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(&format!(r"\s*[{s}]\s+[^{s}]+\s*$", s = TITLE_SEPARATORS)).unwrap()
+});
 
 pub const TABBING_ID: &str = "ai.get-hermes.HermesWebUIDesktop.main";
 
@@ -389,17 +404,14 @@ fn push_tunnel_status(
 /// itself is preserved ("Plan A — Phase 1 — Hermes" → "Plan A — Phase 1").
 /// Returns empty when the title is empty or separator/suffix-only.
 pub fn clean_title(raw: &str) -> String {
-    // Leading `\s*` (not `\s+`) so a session-less title like " — Hermes" (which
-    // trims to "— Hermes", separator at index 0) still strips to empty.
-    let re = regex::Regex::new(r"\s*[—–\-|·]\s+[^—–\-|·]+\s*$").unwrap();
-    let stripped = re.replace(raw.trim(), "").trim().to_string();
+    let stripped = TITLE_SUFFIX_RE.replace(raw.trim(), "").trim().to_string();
     // A remainder that is only separators/whitespace (e.g. a bare "—") is a
     // transient state, not a real session title — collapse it to empty so the
     // caller's guard treats it as "no title". Real titles always contain a
     // non-separator character.
     if stripped
         .chars()
-        .all(|c| c.is_whitespace() || "—–-|·".contains(c))
+        .all(|c| c.is_whitespace() || TITLE_SEPARATORS.contains(c))
     {
         return String::new();
     }


### PR DESCRIPTION
Fully resolves #15 — Windows/Linux tab strip titles never update (stuck on the literal "New Tab"), and an earlier-build variant where titles "instantly reset" to `Hermes WebUI ● <host>`.

## Root cause

The strip's only title source was an injected script (`TITLE_WATCHER`) that posted `document.title` back to native over the JS event IPC:

```
TITLE_WATCHER → EMIT('title', t) → window.__TAURI__.event.emit('bridge', …) → bridge handler → set_tab_title
```

`EMIT` is a silent `try{…}catch{}` that no-ops unless `window.__TAURI__.event` is present and the event IPC is accepted for the tab's **remote** origin. In remote-origin content webviews that path isn't reliable, so the title report silently dropped and the tab kept its `"New Tab".into()` seed (issue failure mode #1). This is the same class of failure the #12 link fix hit — and it fixed it by **not** depending on the remote webview's IPC. The title watcher was never migrated.

macOS was unaffected only because the strip is Windows/Linux-only (`strip::enabled() = cfg!(not(target_os = "macos"))`); macOS uses native WKWebView tabs.

## Fix

**Source the title natively.** Wire wry's native `on_document_title_changed` hook (Tauri 2.11 `WebviewBuilder`/`WebviewWindowBuilder`) on both the strip tab webviews (`strip.rs add_tab`) and the macOS content windows (`windows.rs open_browser`). It fires on the engine's own title-changed signal — implemented on WebView2, WebKitGTK, and WKWebView — so it's independent of page JS, `window.__TAURI__`, and the page CSP. The JS `TITLE_WATCHER` and the now-dead bridge `"title"` handler arm are removed; both paths converge on the new `windows::apply_reported_title`.

**Three more correctness fixes from the issue's analysis:**

1. **Transient-empty guard** (failure mode #2). `apply_reported_title` ignores a report that cleans to empty/separator-only, so a known-good title — or the initial "New Tab" seed — is never downgraded to the `Hermes WebUI ● <host>` fallback while a tab is mid-load.
2. **Generic suffix stripping.** `display_title` stripped a hardcoded ` — Hermes`/` — Hermes Agent`. But the WebUI appends the **configured bot name** or, on a non-default profile, the **profile name**. Now the trailing separator-delimited segment is stripped generically (only the last one, so an em-dash inside the session title itself survives).
3. **Capability covered plain HTTP remote origins.** `content.json` listed `https://*` but no `http://*`, so for a Direct-mode connection to a non-localhost HTTP server (e.g. `http://192.168.x.x:8787`) the capability didn't apply and *every* bridge emit was dropped — including the theme sync and the "response is ready" notification (the issue's corroborating prediction that notify is also dead). Now `http://*`/`http://*:*` are covered. Still event-emit-only — no command access (invariant #7 preserved).

## Why native is the right call (vs. "repair `window.__TAURI__` injection")

The title only needs the page's title string, which the engine already tracks — no IPC required. The native hook can't be defeated by CSP, capability-scope gaps, or missing IPC globals, so it resolves failure mode #1 regardless of which of those is the culprit on a given user's setup. The capability fix (#3) separately restores the *other* bridge emits that genuinely need the IPC.

## Testing

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green.
- Added unit tests: generic suffix stripping (custom bot name, profile name, internal em-dash preserved) and the transient-empty cases (`""`, whitespace, `" — Hermes"`, and that a bare `"Hermes"` is treated as meaningful).
- Native title hook confirmed implemented on all three desktop engines in the locked wry 0.55.1 (`webview2`/`webkitgtk`/`wkwebview`).

## Note for reviewers / verification

The strip is Windows/Linux-only; `HERMES_FORCE_STRIP=1` exercises it on macOS for a local check. A real Windows/Linux smoke (open a couple of sessions, switch tabs, confirm titles track the active session and don't reset) is the high-value manual check before publish.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)
