### PR TITLE
Badge Windows/Linux tabs with a pending approval/clarify popup (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.3.6]
+
+### Added
+
+- **Windows/Linux: tabs now badge when a session is waiting on you.** When a
+  background tab raises a tool-approval or clarify/question popup, you used to
+  see only a momentary flash and had to click through every tab to find the
+  blocked one. Such tabs now show an amber attention dot (and a subtle tint) in
+  the tab strip, so the session waiting for input is obvious at a glance. The
+  signal is the WebUI's existing pending-prompt title marker, read per-tab
+  through the native title hook — no extra polling. (#14, reported by b3nw.)
+
 ## [v0.3.5] — 2026-06-14
 
 ### Fixed

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -17,6 +17,11 @@ pub enum TunnelStatus {
 pub struct TabEntry {
     pub label: String,
     pub title: String,
+    /// The tab's session has a pending approval/clarify popup waiting on the
+    /// user. Derived from the WebUI's leading "● " title marker (issue #14);
+    /// the strip renders an attention badge so a blocked background tab is
+    /// findable without clicking through every tab.
+    pub attention: bool,
 }
 
 /// Per-window tab state for strip mode.

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -256,6 +256,7 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
         entry.tabs.push(TabEntry {
             label: tab_label.clone(),
             title: "New Tab".into(),
+            attention: false,
         });
         entry.active = entry.tabs.len() - 1;
     }
@@ -447,8 +448,10 @@ pub fn layout(app: &AppHandle, window_label: &str) {
     }
 }
 
-/// Title reported by a tab's title-watcher script.
-pub fn set_tab_title(app: &AppHandle, tab_label: &str, raw: &str) {
+/// A tab reported a new title (marker-free) and its pending-attention state.
+/// Called from `windows::apply_reported_title`, which sources both from wry's
+/// native title-changed hook and has already stripped the "● " marker.
+pub fn set_tab_title(app: &AppHandle, tab_label: &str, title: &str, attention: bool) {
     let Some(window_label) = window_of_tab(tab_label) else {
         return;
     };
@@ -457,13 +460,14 @@ pub fn set_tab_title(app: &AppHandle, tab_label: &str, raw: &str) {
         .raw_titles
         .lock()
         .unwrap()
-        .insert(tab_label.to_string(), raw.to_string());
+        .insert(tab_label.to_string(), title.to_string());
     {
         let mut strip = state.strip.lock().unwrap();
         if let Some(entry) = strip.get_mut(&window_label) {
             if let Some(tab) = entry.tabs.iter_mut().find(|t| t.label == tab_label) {
                 let p = prefs::load(app);
-                tab.title = windows::display_title(raw, &p.connection_mode, &p.target_url, true);
+                tab.title = windows::display_title(title, &p.connection_mode, &p.target_url, true);
+                tab.attention = attention;
             }
         }
     }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -7,6 +7,24 @@ use std::sync::atomic::Ordering;
 use std::sync::LazyLock;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
 
+/// The WebUI prepends this glyph (U+25CF + space) to `document.title` when the
+/// view's active session has a pending approval/clarify popup waiting on the
+/// user (hermes-webui `ui.js` `syncTopbar`, #4121). Each tab is its own webview
+/// reporting its own title, so this is a per-tab "needs attention" signal — the
+/// input for the strip's attention badge (issue #14).
+const ATTENTION_MARKER: char = '●';
+
+/// Split a reported `document.title` into (pending-attention, marker-free
+/// title). The marker is stripped so it never leaks into the displayed title
+/// text (the strip renders a proper badge instead, and the macOS window title
+/// stays clean).
+pub fn split_attention(raw: &str) -> (bool, &str) {
+    match raw.trim_start().strip_prefix(ATTENTION_MARKER) {
+        Some(rest) => (true, rest.trim_start()),
+        None => (false, raw),
+    }
+}
+
 /// Title-segment separators the WebUI may place before its trailing name
 /// suffix. Shared by the suffix regex and the separator-only collapse check in
 /// `clean_title` so the two can't drift. The hyphen is last so it reads as a
@@ -482,17 +500,20 @@ pub fn refresh_title(app: &AppHandle, label: &str) {
 /// host"). The 38px strip seed ("New Tab") likewise survives until a real title
 /// arrives.
 pub fn apply_reported_title(app: &AppHandle, label: &str, raw: &str) {
-    if clean_title(raw).is_empty() {
+    let (attention, title) = split_attention(raw);
+    if clean_title(title).is_empty() {
         return;
     }
     if label.starts_with("tab-") {
-        strip::set_tab_title(app, label, raw);
+        strip::set_tab_title(app, label, title, attention);
     } else {
+        // macOS / regular content windows: no per-tab badge, but store the
+        // marker-free title so the native window title never shows a stray "●".
         app.state::<AppState>()
             .raw_titles
             .lock()
             .unwrap()
-            .insert(label.to_string(), raw.to_string());
+            .insert(label.to_string(), title.to_string());
         refresh_title(app, label);
     }
 }
@@ -681,7 +702,28 @@ pub fn open_prefs(app: &AppHandle) {
 
 #[cfg(test)]
 mod tests {
-    use super::{clean_title, display_title};
+    use super::{clean_title, display_title, split_attention};
+
+    #[test]
+    fn splits_pending_attention_marker() {
+        // WebUI prepends "● " for a session with a pending approval/clarify.
+        assert_eq!(
+            split_attention("● My session — Hermes"),
+            (true, "My session — Hermes")
+        );
+        // No marker → not flagged, title untouched.
+        assert_eq!(
+            split_attention("My session — Hermes"),
+            (false, "My session — Hermes")
+        );
+        // Marker survives the suffix strip downstream and yields a real title.
+        let (attn, body) = split_attention("● Untitled — Hermes");
+        assert!(attn);
+        assert_eq!(
+            display_title(body, "ssh", "http://localhost:8787", true),
+            "Untitled"
+        );
+    }
 
     #[test]
     fn strips_hermes_suffix_and_truncates() {

--- a/src/shell.html
+++ b/src/shell.html
@@ -56,6 +56,22 @@
         text-overflow: ellipsis;
         font-size: 12px;
       }
+      /* Attention dot: a tab whose session has a pending approval/clarify
+         popup waiting on the user (issue #14). */
+      .tab .attn {
+        flex: none;
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: #ff9f0a;
+        box-shadow: 0 0 0 2px rgba(255, 159, 10, 0.35);
+      }
+      .tab.attention {
+        color: var(--hermes-fg);
+      }
+      .tab.attention:not(.active) {
+        background: rgba(255, 159, 10, 0.12);
+      }
       .tab .x {
         flex: none;
         width: 18px;
@@ -143,8 +159,19 @@
         root.textContent = "";
         snapshot.tabs.forEach((tab, i) => {
           const el = document.createElement("div");
-          el.className = "tab" + (i === snapshot.active ? " active" : "");
-          el.title = tab.title;
+          el.className =
+            "tab" +
+            (i === snapshot.active ? " active" : "") +
+            (tab.attention ? " attention" : "");
+          el.title = tab.attention
+            ? (tab.title || "New Tab") + " — waiting for you"
+            : tab.title;
+          if (tab.attention) {
+            const dot = document.createElement("span");
+            dot.className = "attn";
+            dot.setAttribute("aria-label", "waiting for you");
+            el.appendChild(dot);
+          }
           const t = document.createElement("span");
           t.className = "t";
           t.textContent = tab.title || "New Tab";


### PR DESCRIPTION
Implements #14 — badge Windows/Linux strip tabs that have a pending approval or clarify/question popup, so a blocked background session is findable at a glance instead of clicking through every tab.

> "when a permission popup occurs in a tab that is not active, you see it briefly appear and vanish, I then have to go through and check each tab to find it." — b3nw

## How it works (no extra WebUI work needed)

The signal already exists in the WebUI: `ui.js` `syncTopbar` prepends a `● ` marker to `document.title` when the view's active session has a pending approval/clarify (`activeSessionHasPendingPromptAttention()`, #4121). Each tab is its own webview reporting its own title, so it's a natural per-tab signal.

The v0.3.5 fix (#15) already moved tab titles onto wry's native `on_document_title_changed` hook, which fires for **background** webviews too. So the shell now sees the marker per-tab with zero extra polling — this PR just consumes it.

## Changes

- **`windows::split_attention`** strips the leading `● ` marker and returns the pending flag. `apply_reported_title` threads it through, so the marker no longer leaks into the displayed title text — and the macOS window title stays clean too.
- **`TabEntry`** gains an `attention: bool`, serialized in the existing `tabs-changed` payload.
- **`set_tab_title`** sets the per-tab flag alongside the (marker-free) title.
- **`shell.html`** renders an amber attention dot + a subtle row tint for flagged tabs, and tweaks the tooltip ("… — waiting for you").

The flag tracks the title both ways: it sets when the popup appears (title gains `● `) and clears when it's resolved (title loses it).

## Scope / notes

- Windows/Linux strip only — that's where the issue lives. macOS uses native tabs (no custom strip); it still benefits from the marker being stripped out of the window title.
- Taskbar flash / bring-to-front (mentioned as "optional" in the issue) is intentionally left as a follow-up to keep this focused on the core strip badge.
- Badge color is amber `#ff9f0a` with `rgba()` (not `color-mix`) so it renders identically across WebView2/WebKitGTK regardless of engine version.

## Testing

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green (9 pass).
- Added `split_attention` unit test (marker present/absent, and that the suffix-strip still yields a clean title after the marker is removed).
- Verified the marker source in the sibling `hermes-webui` checkout (`static/ui.js:6279`).

**Verification gap for review:** the badge-rendering path is logic-tested but not exercised against a live pending-approval popup (requires staging a real approval in a background tab). A quick Win/Linux check — trigger a tool approval in a non-active tab, confirm that tab lights up and clears on answer — is the high-value manual smoke before publish. The strip can be exercised on macOS via `HERMES_FORCE_STRIP=1`.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)
