### PR TITLE
Per-tab profile isolation: give each strip tab its own cookie jar (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.3.7]
+
+### Fixed
+
+- **Windows/Linux: multiple tabs on different profiles no longer bleed into
+  each other.** The WebUI scopes the active profile to a per-client HttpOnly
+  `hermes_profile` cookie, but every tab shared one cookie jar — so switching
+  profile in one tab flipped it for all of them: the sidebar stuck to the
+  last-loaded profile, other profiles' active chats went missing, and the
+  default workspace intermittently failed to apply. Each tab now gets its own
+  isolated data partition (its own cookie jar), so profile selection is
+  genuinely per-tab — the same isolation you get from separate browser windows.
+  A new tab is seeded with the opener tab's profile + login cookies, so it still
+  opens on your current profile (and stays logged in) and only diverges when you
+  switch it. Partitions are session-scoped and cleared on tab close and at
+  startup. (#3, reported by b3nw and Lemz.)
+
 ## [v0.3.6] — 2026-06-14
 
 ### Added

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -193,6 +193,9 @@ fn main() {
                 app.set_menu(m)?;
             }
             bridge::install(&handle);
+            // Wipe stale per-tab cookie partitions from a prior run before any
+            // tab opens (issue #3 — partitions are session-scoped).
+            strip::clear_partitions(&handle);
             {
                 use tauri_plugin_global_shortcut::GlobalShortcutExt;
                 // Conflict with the Swift app's identical default is expected

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -257,6 +257,15 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
         None
     };
     if let Some(ref dir) = partition {
+        // Guarantee a FRESH jar at the point of use. Tab labels are
+        // deterministic and recur every run (window_seq resets to 0 at
+        // startup, so the first tab is always `tab-1-1`), while both the
+        // per-close removal and the startup `clear_partitions` wipe are
+        // best-effort — the OS can hold the WebView2 folder open. If both ever
+        // fail, a same-named tab would otherwise inherit a prior session's
+        // cookies (stale profile/login) instead of opening on the default.
+        // Removing here makes session-scoping hold regardless of cleanup.
+        let _ = std::fs::remove_dir_all(dir);
         let _ = std::fs::create_dir_all(dir);
     }
     // Read the opener's cookies for the target origin BEFORE the new webview is

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -11,8 +11,9 @@
 use crate::state::{AppState, TabEntry, WindowTabs};
 use crate::{bridge, prefs, tunnel, windows};
 use serde_json::json;
+use std::path::PathBuf;
 use std::sync::atomic::Ordering;
-use tauri::webview::{Color, WebviewBuilder};
+use tauri::webview::{Color, Cookie, WebviewBuilder};
 use tauri::window::WindowBuilder;
 use tauri::{
     AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Webview, WebviewUrl, Window, Wry,
@@ -50,6 +51,40 @@ fn content_bounds(win: &Window<Wry>) -> (LogicalPosition<f64>, LogicalSize<f64>)
         LogicalPosition::new(0.0, STRIP_HEIGHT),
         LogicalSize::new(size.width, (size.height - STRIP_HEIGHT).max(0.0)),
     )
+}
+
+/// Per-tab webview data partition path. Each tab gets its own directory → its
+/// own cookie jar, so the WebUI's HttpOnly `hermes_profile` cookie (and the
+/// login session) is scoped to that tab instead of shared across every tab
+/// through one store — the profile-bleed root cause in issue #3.
+fn tab_partition_dir(app: &AppHandle, tab_label: &str) -> Option<PathBuf> {
+    app.path()
+        .app_local_data_dir()
+        .ok()
+        .map(|d| d.join("tab-partitions").join(tab_label))
+}
+
+/// Best-effort removal of a closed tab's data partition. The startup wipe
+/// (`clear_partitions`) is the safety net if this fails because the OS still
+/// holds the folder open immediately after the webview is destroyed.
+fn remove_tab_partition(app: &AppHandle, tab_label: &str) {
+    if let Some(dir) = tab_partition_dir(app, tab_label) {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+/// Wipe all tab data partitions. Called once at startup before any tab opens:
+/// partitions are session-scoped (chats live server-side), so orphans from a
+/// prior run or a crash would otherwise accumulate. No-op when none exist.
+pub fn clear_partitions(app: &AppHandle) {
+    if let Ok(base) = app.path().app_local_data_dir() {
+        let dir = base.join("tab-partitions");
+        if dir.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&dir) {
+                log::warn!("strip: could not clear tab partitions: {e}");
+            }
+        }
+    }
 }
 
 /// Open a new strip window with its first tab. Runs on the caller's thread —
@@ -180,13 +215,19 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
     let allowed_host = target.host_str().map(|h| h.to_lowercase());
 
     let state = app.state::<AppState>();
-    let tab_label = {
+    let (tab_label, opener_label) = {
         let mut strip = state.strip.lock().unwrap();
         let Some(entry) = strip.get_mut(window_label) else {
             return;
         };
+        // The currently-active tab is the opener we seed the new tab's cookies
+        // from (captured before the new tab is pushed and made active).
+        let opener = entry.tabs.get(entry.active).map(|t| t.label.clone());
         entry.tab_seq += 1;
-        format!("tab-{}-{}", window_seq(window_label), entry.tab_seq)
+        (
+            format!("tab-{}-{}", window_seq(window_label), entry.tab_seq),
+            opener,
+        )
     };
 
     let (r, g, b) = prefs::pre_paint_color(app);
@@ -202,10 +243,53 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
     // No injected ssh footer in strip mode — status lives in the strip.
     let init = bridge::init_script(&tab_label, &hex, false);
 
+    // Per-tab cookie isolation (issue #3): the WebUI picks the active profile
+    // via an HttpOnly `hermes_profile` cookie, so a shared cookie jar makes the
+    // profile effectively global — switching profile in one tab bleeds into all
+    // the others. Give each tab its own data partition (separate jar), and seed
+    // it from the opener so a new tab still inherits the current profile + login
+    // (then diverges). Windows/Linux only: WKWebView has no data_directory, and
+    // macOS uses native tabs which this module doesn't drive.
+    let isolate = cfg!(not(target_os = "macos"));
+    let partition = if isolate {
+        tab_partition_dir(app, &tab_label)
+    } else {
+        None
+    };
+    if let Some(ref dir) = partition {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    // Read the opener's cookies for the target origin BEFORE the new webview is
+    // created. Safe here: add_tab runs on a worker thread, so Tauri's cookie
+    // dispatcher marshals to the UI thread without the main-thread deadlock the
+    // docs warn about. (`hermes_profile` is HttpOnly, but the native cookie
+    // store API sees it.)
+    let seed: Vec<Cookie<'static>> = if partition.is_some() {
+        opener_label
+            .and_then(|lbl| find_webview(&win, &lbl))
+            .or_else(|| focused_active_webview(app))
+            .and_then(|wv| wv.cookies_for_url(target.clone()).ok())
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+
+    // When isolating, load about:blank first so cookies can be seeded before
+    // the real navigation — otherwise the first request would race the seed and
+    // the tab would briefly load the wrong profile.
+    let initial_url = if partition.is_some() {
+        WebviewUrl::External(url::Url::parse("about:blank").unwrap())
+    } else {
+        WebviewUrl::External(target.clone())
+    };
+
     let nav_app = app.clone();
     let load_window = window_label.to_string();
-    let wb = WebviewBuilder::new(&tab_label, WebviewUrl::External(target))
-        .background_color(bg)
+    let mut wb = WebviewBuilder::new(&tab_label, initial_url).background_color(bg);
+    if let Some(ref dir) = partition {
+        wb = wb.data_directory(dir.clone());
+    }
+    let wb = wb
         .initialization_script(&init)
         .on_navigation(move |url| {
             windows::navigation_allowed(&nav_app, url, allowed_host.as_deref())
@@ -218,6 +302,10 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
         })
         .on_page_load(move |webview, payload| {
             if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
+                return;
+            }
+            // Ignore the pre-seed about:blank load (isolated tabs only).
+            if payload.url().scheme() == "about" {
                 return;
             }
             let app = webview.app_handle().clone();
@@ -242,6 +330,19 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
             return;
         }
     };
+
+    // Seed the isolated jar from the opener, then load the real target. The
+    // cookies are committed before the navigation request fires (WebKitGTK's
+    // set_cookie is synchronous; WebView2's AddOrUpdateCookie completes before
+    // navigate), so the first load already carries the inherited profile.
+    if partition.is_some() {
+        for cookie in seed {
+            let _ = webview.set_cookie(cookie);
+        }
+        if let Err(e) = webview.navigate(target.clone()) {
+            log::error!("strip: tab navigate failed: {e}");
+        }
+    }
 
     {
         let mut strip = state.strip.lock().unwrap();
@@ -343,6 +444,7 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
     if let Some(wv) = find_webview(&win, tab_label) {
         let _ = wv.close();
     }
+    remove_tab_partition(app, tab_label);
     if let Some(next) = next_active {
         select_tab(app, window_label, &next);
     }
@@ -534,9 +636,14 @@ pub fn forget_window(app: &AppHandle, window_label: &str) {
     let state = app.state::<AppState>();
     let removed = state.strip.lock().unwrap().remove(window_label);
     if let Some(entry) = removed {
-        let mut titles = state.raw_titles.lock().unwrap();
-        for tab in entry.tabs {
-            titles.remove(&tab.label);
+        {
+            let mut titles = state.raw_titles.lock().unwrap();
+            for tab in &entry.tabs {
+                titles.remove(&tab.label);
+            }
+        }
+        for tab in &entry.tabs {
+            remove_tab_partition(app, &tab.label);
         }
     }
 }

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -274,11 +274,33 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
     // docs warn about. (`hermes_profile` is HttpOnly, but the native cookie
     // store API sees it.)
     let seed: Vec<Cookie<'static>> = if partition.is_some() {
-        opener_label
+        match opener_label
             .and_then(|lbl| find_webview(&win, &lbl))
             .or_else(|| focused_active_webview(app))
-            .and_then(|wv| wv.cookies_for_url(target.clone()).ok())
-            .unwrap_or_default()
+        {
+            Some(opener) => {
+                match opener.cookies_for_url(target.clone()) {
+                    Ok(cookies) => {
+                        log::debug!(
+                            "strip: seeding {tab_label} from opener ({} cookies)",
+                            cookies.len()
+                        );
+                        cookies
+                    }
+                    // Fail open to the default profile (and re-login if auth) — log
+                    // so the multi-profile smoke can tell a seed-read failure apart
+                    // from a genuinely empty jar.
+                    Err(e) => {
+                        log::debug!("strip: seed read failed for {tab_label}: {e} (opens on default profile)");
+                        Vec::new()
+                    }
+                }
+            }
+            None => {
+                log::debug!("strip: no opener for {tab_label} (opens on default profile)");
+                Vec::new()
+            }
+        }
     } else {
         Vec::new()
     };


### PR DESCRIPTION
Full resolution of #3 — Windows/Linux multi-profile tab bleed (three independent reports: b3nw, Lemz, + b3nw's "not all active chats appear" follow-up).

## Root cause (confirmed, not a WebUI bug)

The WebUI selects the active profile **per-client via an HttpOnly `hermes_profile` cookie** (no query/header/path alternative — verified in the server). Separate browsers isolate correctly because they have separate cookie jars; the desktop strip's tabs **all shared one jar**, so switching profile in one tab flipped the cookie for every tab. That single root cause produces all three reported symptoms:
- sidebar/profile sticks to the last-loaded profile across tabs,
- other profiles' active chats are missing from the sidebar,
- the per-profile default workspace intermittently fails to apply.

## Fix (wrapper-side — the issue's proposed direction)

**Each tab webview now gets its own `data_directory`** (Windows/Linux) → its own cookie jar → profile selection is genuinely per-tab.

To avoid regressing the common single-profile / authenticated case (a fresh jar would mean "new tab = default profile + re-login"), **a new tab is seeded from the opener tab**:
1. Before creating the webview, read the opener's cookies for the target origin via the native cookie store (`cookies_for_url` — sees HttpOnly cookies), on the worker thread so Tauri's dispatcher marshals to the UI thread without the [documented main-thread `cookies()` deadlock](https://github.com/tauri-apps/wry/issues/583).
2. Create the tab at `about:blank` with its isolated `data_directory`.
3. `set_cookie` the seeded cookies, then `navigate()` to the target.

Seeding-before-navigation is **race-free**: WebKitGTK's `set_cookie` is synchronous (pumps until the add completes) and WebView2's `AddOrUpdateCookie` completes before `navigate`, so the first real request already carries the inherited `hermes_profile` + `hermes_session`. Net behavior: a new tab opens on your current profile and stays logged in, and only diverges when you switch *that tab's* profile — multi-profile tabs no longer bleed.

**Lifecycle:** partitions are session-scoped — removed on tab close (`close_tab`) and window close (`forget_window`), and wiped at startup (`clear_partitions` in `setup`, before any tab opens) so an orphan from a crash can't accumulate. (Per-close removal is best-effort since the OS may briefly hold the WebView2 folder; the startup wipe is the safety net.)

**Platform scope:** gated to `cfg!(not(target_os = "macos"))`. macOS uses native tabs (this module is Windows/Linux only) and WKWebView has no `data_directory`. macOS native-tab isolation would be a separate change via `data_store_identifier` (macOS 14+) and isn't part of issue #3.

## Known side effect (intentional)

`data_directory` isolates *all* per-origin storage, so **localStorage is now per-tab too** — e.g. the WebUI's theme/skin localStorage sync no longer crosses tabs. This is consistent with the "each tab is like a separate browser" model the reporters rely on; cookies (profile + login) are seeded, theme is not. Window chrome theme still seeds from the native theme cache.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (9) green.
- `cargo xwin check --target x86_64-pc-windows-msvc` clean — the isolation path is live on Windows and compiles cleanly there.
- All Tauri/wry APIs confirmed in the locked sources: `data_directory`, `cookies_for_url`/`set_cookie` (read+write, all three desktop engines), `navigate`, `PageLoadPayload::url()`.

**Verification gap — please review/smoke before release.** The isolation + seeding path only *executes* on Windows/Linux (`isolate` is `false` on macOS, so even `HERMES_FORCE_STRIP` won't exercise it on a Mac). The logic is reasoned and compiles clean on both targets, but the real behavior needs a live check on Windows/Linux:
1. Open two tabs, set them to different profiles → each sidebar shows its own profile; switching tabs doesn't cross-contaminate; both profiles' chats are visible in their own tab.
2. Single profile: open a new tab → it inherits the current profile and (if auth) stays logged in.
3. If auth is enabled, confirm the seed carries the session (no re-login on a new tab).

Suggested for the independent review: confirm the seed-before-navigate ordering holds on real WebView2 (the AddOrUpdateCookie→navigate sequencing), and that per-tab WebView2 user-data folders don't contend. The Linux smoke already exercises the isolated-tab create+load path.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
