### PR TITLE
Tabs & sessions (v0.4.0): restore windows/tabs, per-tab profile dot, drag-reorder, macOS single-tab drag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [v0.4.0] — 2026-06-17
+
+A tabs & sessions release across macOS, Windows, and Linux.
+
+### Added
+
+- **Your windows and tabs come back after you quit or update the app**
+  (issue #18). The shell now remembers each window's tabs — their order, which
+  one was active, each tab's URL, and each tab's profile — and restores them on
+  the next launch (including after an in-app update relaunches). Previously
+  every restart reopened a single empty tab and the rest were lost. Works on all
+  three platforms: macOS rebuilds the native window tab groups; Windows/Linux
+  rebuild the tab strip. Each restored tab reopens on the profile it was on (the
+  profile selector is re-seeded). Notes: a server that requires login will ask
+  you to sign in again after a restart (only the profile selector is persisted,
+  never login/auth cookies); the session is saved for the server you're
+  connected to and isn't restored if you switch to a different server.
+- **Per-tab profile dot** (issue #8, Windows/Linux tab strip). Each tab shows a
+  small colored dot keyed to its active profile, so several profiles open at
+  once are easy to tell apart at a glance; the default profile shows no dot.
+  Hovering a tab shows its profile name. Pairs with the per-tab profile
+  isolation added in v0.3.7/v0.3.8.
+- **Drag tabs left/right to reorder them** in the Windows/Linux tab strip
+  (issue #19). macOS already reorders via native window tabs; the custom strip
+  had no way to. The new order is what gets saved and restored.
+
+### Fixed
+
+- **macOS: you couldn't drag the window by the title bar when only one tab was
+  open** (issue #22). Window dragging relied on Tauri's JS-based drag region,
+  which doesn't work reliably in the remote-content webview — so with a single
+  tab (no native tab bar to grab) the window wouldn't move. Dragging now uses
+  WebKit's built-in native drag region (`-webkit-app-region`), which is
+  independent of that fragile IPC and works regardless of how many tabs are
+  open. (Same remote-webview limitation behind the earlier title (#15) and
+  external-link (#12) fixes.)
+
+### Known issues
+
+- The app icon still shows a faint light edge on its rounded corners (issue #5)
+  — the icon artwork has a light border baked in, so a clean fix needs the
+  source logo and a proper icon pass rather than editing the rendered images.
+  Tracked for a follow-up.
+
 ## [v0.3.8] — 2026-06-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.3.8"
+version = "0.4.0"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -59,13 +59,32 @@ const PASTE_SUPPRESS: &str = r##"
 
 /// S7/S8/S9 — macOS overlay-titlebar integration: traffic-light clearance,
 /// hide the page logo (collides with traffic lights), CSS rule for hiding the
-/// page titlebar when the native tab bar shows, drag region on .app-titlebar.
+/// page titlebar when the native tab bar shows, and a NATIVE drag region on
+/// `.app-titlebar`.
+///
+/// Window dragging uses WKWebView's built-in `-webkit-app-region: drag` (the
+/// same mechanism AppKit/Electron use for frameless drag) rather than Tauri's
+/// `data-tauri-drag-region`. The Tauri attribute drives dragging through a
+/// JS→native IPC that is unreliable in remote-origin webviews — the same
+/// remote-IPC fragility that broke titles (#15) and external links (#12) — so
+/// with a single tab (no native tab bar to drag) the window couldn't be moved
+/// at all (issue #22). `-webkit-app-region` is honored natively by WKWebView,
+/// independent of IPC/CSP/capability scope, and works regardless of tab count.
+/// Interactive children are marked `no-drag` so the titlebar's buttons/inputs
+/// still receive clicks. The `data-tauri-drag-region` attribute is kept as a
+/// belt-and-suspenders fallback (harmless when the CSS already handles it).
 const MACOS_TITLEBAR: &str = r##"
   try { document.documentElement.style.setProperty('--traffic-light-width', '80px'); } catch (e) {}
   (function () {
     try {
       var s = document.createElement('style');
-      s.textContent = '.app-titlebar-icon { visibility: hidden !important; } body.hermes-mac-tabbed .app-titlebar { display: none !important; }';
+      s.textContent =
+        '.app-titlebar-icon { visibility: hidden !important; } ' +
+        'body.hermes-mac-tabbed .app-titlebar { display: none !important; } ' +
+        '.app-titlebar { -webkit-app-region: drag; } ' +
+        '.app-titlebar button, .app-titlebar a, .app-titlebar input, .app-titlebar select, ' +
+        '.app-titlebar textarea, .app-titlebar [role="button"], .app-titlebar [contenteditable], ' +
+        '.app-titlebar [data-no-drag] { -webkit-app-region: no-drag; }';
       (document.head || document.documentElement).appendChild(s);
     } catch (e) {}
   })();

--- a/src-tauri/src/conn.rs
+++ b/src-tauri/src/conn.rs
@@ -3,7 +3,7 @@
 //! | error window. Single-flight guarded.
 
 use crate::state::AppState;
-use crate::{health, prefs, tunnel, windows};
+use crate::{health, prefs, session, tunnel, windows};
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
@@ -143,7 +143,8 @@ fn run(app: &AppHandle) {
             if let Some(last) = content.last() {
                 let _ = last.set_focus();
             }
-        } else {
+        } else if !session::maybe_restore(app) {
+            // First connect with no replayable session → one fresh window.
             windows::open_browser(app, &p, false);
         }
         windows::set_offline_badge(app, false);

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -191,7 +191,15 @@ pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
             let Some(member) = by_ptr.get(ptr) else {
                 continue;
             };
-            let url = crate::session::capture_url(|| member.url()).unwrap_or_else(|| target.clone());
+            // Only read the live URL once the window has committed a real
+            // navigation — url() on a not-yet-navigated WKWebView unwraps a nil
+            // NSURL and panics (poisoning a runtime mutex → SIGABRT).
+            let url = if crate::session::has_navigated(app, member.label()) {
+                crate::session::capture_url(|| member.url())
+            } else {
+                None
+            }
+            .unwrap_or_else(|| target.clone());
             if Some(i) == selected {
                 active = tabs.len();
             }
@@ -208,7 +216,12 @@ pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
             None
         } else if let (Ok(pos), Ok(sz)) = (w.outer_position(), w.inner_size()) {
             if sz.width >= 200 && sz.height >= 200 {
-                Some([pos.x as i64, pos.y as i64, sz.width as i64, sz.height as i64])
+                Some([
+                    pos.x as i64,
+                    pos.y as i64,
+                    sz.width as i64,
+                    sz.height as i64,
+                ])
             } else {
                 None
             }

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -18,7 +18,7 @@ use objc2::ClassType;
 use objc2_app_kit::{NSView, NSWindow, NSWindowOrderingMode, NSWindowTabbingMode};
 use objc2_foundation::{CGPoint, CGRect, CGSize};
 use std::ffi::c_void;
-use tauri::WebviewWindow;
+use tauri::{AppHandle, Manager, WebviewWindow};
 
 // ---- GCD main-queue dispatch ----
 //
@@ -142,6 +142,111 @@ pub fn update_webview_layout(window: &WebviewWindow) -> bool {
             }
         }
         tab_visible
+    }
+}
+
+/// Capture macOS content windows as session windows (issue #18). Native tab
+/// grouping is the source of truth (we get no KVO for user-driven
+/// drag-out/merge/reorder), so this queries each window's `NSWindowTabGroup`:
+/// windows in the same group become one session window, in the group's order,
+/// with the selected tab marked active. Per-tab profile comes from the
+/// `window_profiles` map (captured at page load); the URL from the live
+/// webview. MUST run on the main thread (AppKit + webview getters).
+pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
+    use crate::session::{SessionTab, SessionWindow};
+    use std::collections::{HashMap, HashSet};
+
+    let wins = crate::windows::content_windows(app);
+    let target = crate::prefs::load(app).target_url;
+    let profiles = {
+        let state = app.state::<crate::state::AppState>();
+        let g = state.window_profiles.lock().unwrap();
+        g.clone()
+    };
+    // ns_window pointer -> WebviewWindow
+    let mut by_ptr: HashMap<usize, WebviewWindow> = HashMap::new();
+    for w in &wins {
+        if let Ok(ptr) = w.ns_window() {
+            by_ptr.insert(ptr as usize, w.clone());
+        }
+    }
+
+    let mut seen: HashSet<usize> = HashSet::new();
+    let mut out = Vec::new();
+    for w in &wins {
+        let Ok(self_ptr) = w.ns_window() else {
+            continue;
+        };
+        if seen.contains(&(self_ptr as usize)) {
+            continue;
+        }
+        let (mut ordered, selected) = tab_group_ptrs(w);
+        if ordered.is_empty() {
+            ordered.push(self_ptr as usize); // standalone window = a group of one
+        }
+        let mut tabs = Vec::new();
+        let mut active = 0usize;
+        for (i, ptr) in ordered.iter().enumerate() {
+            seen.insert(*ptr);
+            let Some(member) = by_ptr.get(ptr) else {
+                continue;
+            };
+            let url = crate::session::capture_url(|| member.url()).unwrap_or_else(|| target.clone());
+            if Some(i) == selected {
+                active = tabs.len();
+            }
+            tabs.push(SessionTab {
+                url,
+                profile: profiles.get(member.label()).cloned(),
+            });
+        }
+        if tabs.is_empty() {
+            continue;
+        }
+        // The group shares one frame — read it off the queried window.
+        let frame = if w.is_minimized().unwrap_or(false) || w.is_fullscreen().unwrap_or(false) {
+            None
+        } else if let (Ok(pos), Ok(sz)) = (w.outer_position(), w.inner_size()) {
+            if sz.width >= 200 && sz.height >= 200 {
+                Some([pos.x as i64, pos.y as i64, sz.width as i64, sz.height as i64])
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        out.push(SessionWindow {
+            frame,
+            active: active.min(tabs.len() - 1),
+            tabs,
+        });
+    }
+    out
+}
+
+/// Ordered ns_window pointers of `window`'s native tab group + the selected
+/// index within that order. Empty vec when the window is in no tab group.
+fn tab_group_ptrs(window: &WebviewWindow) -> (Vec<usize>, Option<usize>) {
+    let Ok(ptr) = window.ns_window() else {
+        return (Vec::new(), None);
+    };
+    unsafe {
+        let ns: &NSWindow = &*(ptr as *const NSWindow);
+        let Some(group) = ns.tabGroup() else {
+            return (Vec::new(), None);
+        };
+        let arr = group.windows();
+        let count = arr.count();
+        let mut ptrs = Vec::with_capacity(count);
+        for i in 0..count {
+            let w = arr.objectAtIndex(i);
+            ptrs.push(&*w as *const NSWindow as usize);
+        }
+        let sel_idx = group.selectedWindow().and_then(|sel| {
+            let sp = &*sel as *const NSWindow as usize;
+            ptrs.iter().position(|p| *p == sp)
+        });
+        (ptrs, sel_idx)
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,6 +8,7 @@ mod macos;
 mod menu;
 mod paste;
 mod prefs;
+mod session;
 mod state;
 mod strip;
 mod theme;
@@ -82,6 +83,11 @@ fn tab_select(app: tauri::AppHandle, window: String, tab: String) {
 #[tauri::command]
 fn tab_close(app: tauri::AppHandle, window: String, tab: String) {
     std::thread::spawn(move || strip::close_tab(&app, &window, &tab));
+}
+
+#[tauri::command]
+fn tab_reorder(app: tauri::AppHandle, window: String, tab: String, index: usize) {
+    std::thread::spawn(move || strip::reorder_tab(&app, &window, &tab, index));
 }
 
 #[tauri::command]
@@ -176,6 +182,7 @@ fn main() {
             tab_new,
             tab_select,
             tab_close,
+            tab_reorder,
             new_window_cmd,
             strip_menu
         ])
@@ -240,6 +247,17 @@ fn main() {
                 std::thread::spawn(move || {
                     std::thread::sleep(std::time::Duration::from_secs(10));
                     updater::spawn_check(&update_handle, false);
+                });
+            }
+            // Session autosave (issue #18): periodically capture windows/tabs so
+            // a frame move or an SPA navigation (neither of which fires a
+            // structural event) is reflected. Cheap — `persist` writes only when
+            // the captured session differs from the last write.
+            {
+                let sess_handle = handle.clone();
+                std::thread::spawn(move || loop {
+                    std::thread::sleep(std::time::Duration::from_secs(4));
+                    session::persist(&sess_handle);
                 });
             }
             // Chrome poller — the Tauri stand-in for the Swift app's

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -200,11 +200,46 @@ pub fn maybe_restore(app: &AppHandle) -> bool {
         }
     }
     state.restoring.store(false, Ordering::SeqCst);
+    // Guard against a total restore failure leaving the app with zero windows
+    // (on Win/Linux a later Destroyed event could then quit the app). If
+    // nothing was built, fall through so the caller opens one bare window.
+    if crate::windows::content_window_handles(app).is_empty() {
+        log::warn!("session: restore produced no windows — opening a fresh one");
+        return false;
+    }
     // Deliberately DON'T persist here: the restored tabs haven't navigated yet
     // (the seed+navigate is deferred), so a capture now would read about:blank
     // and clobber the saved URLs. `last_session` is already seeded with the
     // saved blob; the periodic autosave re-captures once the tabs have loaded.
     true
+}
+
+/// Record that a webview/window has committed at least one real navigation, so
+/// session capture may safely read its live URL (see `AppState.navigated`).
+pub fn mark_navigated(app: &AppHandle, label: &str) {
+    app.state::<AppState>()
+        .navigated
+        .lock()
+        .unwrap()
+        .insert(label.to_string());
+}
+
+/// Whether `label` has committed a real navigation (URL is non-nil).
+pub fn has_navigated(app: &AppHandle, label: &str) -> bool {
+    app.state::<AppState>()
+        .navigated
+        .lock()
+        .unwrap()
+        .contains(label)
+}
+
+/// Drop a closed webview/window from the navigated set.
+pub fn forget_navigated(app: &AppHandle, label: &str) {
+    app.state::<AppState>()
+        .navigated
+        .lock()
+        .unwrap()
+        .remove(label);
 }
 
 /// Read a webview's current URL, tolerating the engine not having set one yet.
@@ -284,7 +319,8 @@ mod tests {
     fn tolerates_partial_blob() {
         // Older/partial saved sessions must deserialize via serde defaults
         // rather than dropping the whole restore.
-        let j = r#"{"mode":"direct","target":"http://x","windows":[{"tabs":[{"url":"http://x"}]}]}"#;
+        let j =
+            r#"{"mode":"direct","target":"http://x","windows":[{"tabs":[{"url":"http://x"}]}]}"#;
         let s: Session = serde_json::from_str(j).unwrap();
         assert_eq!(s.windows[0].active, 0);
         assert!(s.windows[0].frame.is_none());

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -1,0 +1,293 @@
+//! Session persistence — bring the user's windows + tabs back across restart
+//! and in-app updates (issue #18). The server owns chat content; the shell
+//! persists just enough to recreate the *shape* of the workspace: per window,
+//! the ordered set of tabs (each tab's current URL + active WebUI profile),
+//! which tab was active, and the window frame. On the first successful
+//! connection of a fresh launch the saved session is replayed instead of
+//! opening one bare tab.
+//!
+//! Two tab models feed this (see [`crate::strip`] / [`crate::windows`]):
+//!   * Windows/Linux strip — the `AppState.strip` registry is the source of
+//!     truth (tab order/active/profile live there already).
+//!   * macOS native tabs — NSWindow tab groups are queried via objc2
+//!     ([`crate::macos::session_windows`]) so user-driven drag/merge/reorder is
+//!     captured faithfully (we get no KVO for those).
+//!
+//! Restoration re-seeds each tab's `hermes_profile` cookie so it reopens on the
+//! same profile (the per-tab profile isolation of v0.3.7/v0.3.8). Only that
+//! non-sensitive profile *selector* is persisted — never auth/login/session
+//! cookies — so an authenticated server simply re-prompts for login after a
+//! restart. The cookie is reconstructed host-only + HttpOnly + Path=/ to match
+//! how the WebUI sets it.
+
+use crate::state::AppState;
+use crate::{prefs, strip};
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::Ordering;
+use std::sync::mpsc;
+use std::time::Duration;
+use tauri::{AppHandle, Manager};
+
+const KEY: &str = "session";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionTab {
+    pub url: String,
+    #[serde(default)]
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SessionWindow {
+    /// [x, y, w, h] in physical pixels, or None to center/cascade.
+    #[serde(default)]
+    pub frame: Option<[i64; 4]>,
+    #[serde(default)]
+    pub active: usize,
+    pub tabs: Vec<SessionTab>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Session {
+    pub mode: String,
+    pub target: String,
+    pub windows: Vec<SessionWindow>,
+}
+
+/// Reconstruct the WebUI's `hermes_profile` cookie for re-seeding a restored
+/// tab. Host-only (no Domain), HttpOnly, Path=/ — matching the server's
+/// `Set-Cookie` so the WebUI reads it back as the same selector.
+pub fn profile_cookie(value: &str) -> tauri::webview::Cookie<'static> {
+    let mut c = tauri::webview::Cookie::new("hermes_profile".to_string(), value.to_string());
+    c.set_path("/");
+    c.set_http_only(true);
+    c
+}
+
+// ---- store I/O ----
+
+pub fn save(app: &AppHandle, s: &Session) {
+    use tauri_plugin_store::StoreExt;
+    if let Ok(store) = app.store(prefs::STORE_FILE) {
+        if let Ok(v) = serde_json::to_value(s) {
+            store.set(KEY, v);
+            let _ = store.save();
+        }
+    }
+}
+
+pub fn load(app: &AppHandle) -> Option<Session> {
+    use tauri_plugin_store::StoreExt;
+    let store = app.store(prefs::STORE_FILE).ok()?;
+    let v = store.get(KEY)?;
+    serde_json::from_value(v).ok()
+}
+
+// ---- capture ----
+
+/// Build a [`Session`] from the live window/tab state. Runs the actual read on
+/// the main thread (AppKit tab-group queries on macOS, webview URL getters
+/// everywhere must touch the runtime on its own thread) and blocks the caller
+/// for the result — so call it only from a worker thread, never the main one.
+fn capture(app: &AppHandle) -> Session {
+    let (tx, rx) = mpsc::channel();
+    let app2 = app.clone();
+    if app
+        .run_on_main_thread(move || {
+            let _ = tx.send(capture_inner(&app2));
+        })
+        .is_err()
+    {
+        return Session::default();
+    }
+    rx.recv_timeout(Duration::from_secs(2)).unwrap_or_default()
+}
+
+fn capture_inner(app: &AppHandle) -> Session {
+    let p = prefs::load(app);
+    let windows = if strip::enabled() {
+        strip::session_windows(app)
+    } else {
+        #[cfg(target_os = "macos")]
+        {
+            crate::macos::session_windows(app)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Vec::new()
+        }
+    };
+    Session {
+        mode: p.connection_mode,
+        target: p.target_url,
+        windows,
+    }
+}
+
+/// Capture the current session and persist it — but only if it changed since
+/// the last write (cheap dedupe so the periodic tick + structural-change calls
+/// don't thrash the store). Off-loads to a worker thread; overlapping calls are
+/// dropped (the periodic tick recovers anything missed).
+pub fn persist(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    // Never write while restore is rebuilding windows — a half-built capture
+    // would clobber the saved session. (A capture before the first connect is
+    // harmless: it's empty and the empty-guard below drops it.)
+    if state.restoring.load(Ordering::SeqCst) {
+        return;
+    }
+    if state.persist_busy.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let app = app.clone();
+    std::thread::spawn(move || {
+        let s = capture(&app);
+        let state = app.state::<AppState>();
+        // Never overwrite a real saved session with an empty capture (e.g. a
+        // transient zero-window moment during reconnect).
+        if !s.windows.is_empty() {
+            let json = serde_json::to_string(&s).unwrap_or_default();
+            let mut last = state.last_session.lock().unwrap();
+            if *last != json {
+                *last = json;
+                drop(last);
+                save(&app, &s);
+            }
+        }
+        state.persist_busy.store(false, Ordering::SeqCst);
+    });
+}
+
+// ---- restore ----
+
+/// On the FIRST successful connection of a launch, replay the saved session if
+/// one exists and matches the current connection (same mode + target — a
+/// different server's tabs/profiles wouldn't make sense). Returns true if it
+/// restored windows; false if the caller should fall back to opening one bare
+/// window. Marks the session as restored either way.
+pub fn maybe_restore(app: &AppHandle) -> bool {
+    let state = app.state::<AppState>();
+    if state.session_restored.swap(true, Ordering::SeqCst) {
+        return false; // already handled this launch
+    }
+    let p = prefs::load(app);
+    let Some(saved) = load(app) else {
+        return false;
+    };
+    if saved.windows.is_empty() || saved.mode != p.connection_mode || saved.target != p.target_url {
+        return false;
+    }
+    // Seed last_session so the first persist() doesn't immediately rewrite an
+    // identical blob.
+    if let Ok(json) = serde_json::to_string(&saved) {
+        *state.last_session.lock().unwrap() = json;
+    }
+    let total: usize = saved.windows.iter().map(|w| w.tabs.len()).sum();
+    log::info!(
+        "session: restoring {} window(s), {} tab(s)",
+        saved.windows.len(),
+        total
+    );
+    state.restoring.store(true, Ordering::SeqCst);
+    if strip::enabled() {
+        for sw in &saved.windows {
+            strip::restore_window(app, sw);
+        }
+    } else {
+        #[cfg(target_os = "macos")]
+        for sw in &saved.windows {
+            crate::windows::restore_macos_window(app, sw);
+        }
+    }
+    state.restoring.store(false, Ordering::SeqCst);
+    // Deliberately DON'T persist here: the restored tabs haven't navigated yet
+    // (the seed+navigate is deferred), so a capture now would read about:blank
+    // and clobber the saved URLs. `last_session` is already seeded with the
+    // saved blob; the periodic autosave re-captures once the tabs have loaded.
+    true
+}
+
+/// Read a webview's current URL, tolerating the engine not having set one yet.
+/// wry's `url()` unwraps the native URL (nil for a freshly-created, not-yet-
+/// navigated webview) and panics — and capture can race a just-opened tab — so
+/// guard it. Returns None for nil/`about:` URLs (callers fall back to target).
+pub fn capture_url(get: impl FnOnce() -> tauri::Result<url::Url>) -> Option<String> {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| get().ok()))
+        .ok()
+        .flatten()
+        .map(|u| u.to_string())
+        .filter(|u| !u.starts_with("about:"))
+}
+
+/// Frame helper shared by both capture paths.
+pub fn frame_of(win: &tauri::Window) -> Option<[i64; 4]> {
+    if win.is_minimized().unwrap_or(false) || win.is_fullscreen().unwrap_or(false) {
+        return None;
+    }
+    let pos = win.outer_position().ok()?;
+    let size = win.inner_size().ok()?;
+    if size.width < 200 || size.height < 200 {
+        return None;
+    }
+    Some([
+        pos.x as i64,
+        pos.y as i64,
+        size.width as i64,
+        size.height as i64,
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_round_trips() {
+        let s = Session {
+            mode: "direct".into(),
+            target: "http://localhost:8787".into(),
+            windows: vec![SessionWindow {
+                frame: Some([10, 20, 1280, 830]),
+                active: 1,
+                tabs: vec![
+                    SessionTab {
+                        url: "http://localhost:8787/".into(),
+                        profile: None,
+                    },
+                    SessionTab {
+                        url: "http://localhost:8787/c/42".into(),
+                        profile: Some("work".into()),
+                    },
+                ],
+            }],
+        };
+        let back: Session = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert_eq!(back.windows.len(), 1);
+        assert_eq!(back.windows[0].active, 1);
+        assert_eq!(back.windows[0].frame, Some([10, 20, 1280, 830]));
+        assert_eq!(back.windows[0].tabs[1].profile.as_deref(), Some("work"));
+    }
+
+    #[test]
+    fn profile_cookie_matches_webui_attrs() {
+        // Must reconstruct the host-only + HttpOnly + Path=/ cookie the server
+        // sets, or a restored tab wouldn't be recognized on the right profile.
+        let c = profile_cookie("work");
+        assert_eq!(c.name(), "hermes_profile");
+        assert_eq!(c.value(), "work");
+        assert_eq!(c.path(), Some("/"));
+        assert_eq!(c.http_only(), Some(true));
+        assert_eq!(c.domain(), None); // host-only
+    }
+
+    #[test]
+    fn tolerates_partial_blob() {
+        // Older/partial saved sessions must deserialize via serde defaults
+        // rather than dropping the whole restore.
+        let j = r#"{"mode":"direct","target":"http://x","windows":[{"tabs":[{"url":"http://x"}]}]}"#;
+        let s: Session = serde_json::from_str(j).unwrap();
+        assert_eq!(s.windows[0].active, 0);
+        assert!(s.windows[0].frame.is_none());
+        assert!(s.windows[0].tabs[0].profile.is_none());
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -22,6 +22,12 @@ pub struct TabEntry {
     /// the strip renders an attention badge so a blocked background tab is
     /// findable without clicking through every tab.
     pub attention: bool,
+    /// The active WebUI profile for this tab — the value of its per-tab
+    /// `hermes_profile` cookie (None = the default profile). Read from the
+    /// tab's isolated cookie jar after each real page load. Drives the strip's
+    /// per-tab profile dot (issue #8) and is persisted so a restored tab
+    /// reopens on the same profile (issue #18).
+    pub profile: Option<String>,
 }
 
 /// Per-window tab state for strip mode.
@@ -52,6 +58,24 @@ pub struct AppState {
     pub ui_state: Mutex<HashMap<String, (bool, bool)>>,
     /// Strip-mode (Windows/Linux) tab registry: window label -> tabs.
     pub strip: Mutex<HashMap<String, WindowTabs>>,
+    /// macOS only: content-window label -> active `hermes_profile` value (the
+    /// strip stores this per-TabEntry instead). Absent = default profile.
+    /// Feeds session capture so a restored native tab reopens on its profile.
+    pub window_profiles: Mutex<HashMap<String, String>>,
+    /// Set once the saved-session decision has been made on this launch —
+    /// restore runs on the FIRST successful connect only, never on later
+    /// same-process reconnects/mode-switches (issue #18).
+    pub session_restored: AtomicBool,
+    /// Held while restore is rebuilding windows so a mid-restore `persist`
+    /// can't clobber the saved session with a half-built capture.
+    pub restoring: AtomicBool,
+    /// Single-flight guard for `session::persist` (skip overlapping captures;
+    /// the periodic tick catches anything dropped).
+    pub persist_busy: AtomicBool,
+    /// Serialized form of the last-saved session — persist writes only when the
+    /// captured session differs, so the periodic tick + event calls don't thrash
+    /// the store.
+    pub last_session: Mutex<String>,
     /// The ssh child process, if a tunnel is up.
     pub tunnel_child: Mutex<Option<Child>>,
     pub tunnel_status: Mutex<TunnelStatus>,
@@ -74,6 +98,11 @@ impl AppState {
             raw_titles: Mutex::new(HashMap::new()),
             ui_state: Mutex::new(HashMap::new()),
             strip: Mutex::new(HashMap::new()),
+            window_profiles: Mutex::new(HashMap::new()),
+            session_restored: AtomicBool::new(false),
+            restoring: AtomicBool::new(false),
+            persist_busy: AtomicBool::new(false),
+            last_session: Mutex::new(String::new()),
             tunnel_child: Mutex::new(None),
             tunnel_status: Mutex::new(TunnelStatus::Disconnected),
             stderr_tail: Mutex::new(Vec::new()),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::process::Child;
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Mutex;
@@ -62,6 +62,13 @@ pub struct AppState {
     /// strip stores this per-TabEntry instead). Absent = default profile.
     /// Feeds session capture so a restored native tab reopens on its profile.
     pub window_profiles: Mutex<HashMap<String, String>>,
+    /// Webview/window labels that have committed at least one real (non-`about:`)
+    /// navigation. Session capture reads a webview's live URL ONLY for these:
+    /// wry's macOS `url()` unwraps a nil `WKWebView.URL` on a not-yet-navigated
+    /// webview and panics — and that panic poisons a tauri-runtime-wry mutex
+    /// mid-dispatch, so a later `navigate()` aborts the process (caught unwinds
+    /// don't undo the poison). Gating the call is the only safe fix.
+    pub navigated: Mutex<HashSet<String>>,
     /// Set once the saved-session decision has been made on this launch —
     /// restore runs on the FIRST successful connect only, never on later
     /// same-process reconnects/mode-switches (issue #18).
@@ -99,6 +106,7 @@ impl AppState {
             ui_state: Mutex::new(HashMap::new()),
             strip: Mutex::new(HashMap::new()),
             window_profiles: Mutex::new(HashMap::new()),
+            navigated: Mutex::new(HashSet::new()),
             session_restored: AtomicBool::new(false),
             restoring: AtomicBool::new(false),
             persist_busy: AtomicBool::new(false),

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -90,6 +90,22 @@ pub fn clear_partitions(app: &AppHandle) {
 /// Open a new strip window with its first tab. Runs on the caller's thread —
 /// callers must already be off the main thread (CLAUDE.md invariant #9).
 pub fn open_browser_window(app: &AppHandle, p: &prefs::Prefs) {
+    if let Some(label) = build_strip_window(app, p, None) {
+        add_tab(app, &label);
+        log::info!("strip: window {label} ready");
+    }
+}
+
+/// Build a strip window (OS window + 38px shell webview + frame) WITHOUT any
+/// content tab, returning its label. Shared by `open_browser_window` (then adds
+/// one tab) and session restore (then adds the saved tabs). `frame_override`,
+/// when set, positions/sizes the window to a saved frame instead of the
+/// first-window-restore / cascade default. Caller must be off the main thread.
+fn build_strip_window(
+    app: &AppHandle,
+    p: &prefs::Prefs,
+    frame_override: Option<[i64; 4]>,
+) -> Option<String> {
     let state = app.state::<AppState>();
     let n = state.window_seq.fetch_add(1, Ordering::SeqCst) + 1;
     let label = format!("main-{n}");
@@ -106,7 +122,7 @@ pub fn open_browser_window(app: &AppHandle, p: &prefs::Prefs) {
         Ok(w) => w,
         Err(e) => {
             log::error!("strip: window build failed: {e}");
-            return;
+            return None;
         }
     };
 
@@ -141,8 +157,12 @@ pub fn open_browser_window(app: &AppHandle, p: &prefs::Prefs) {
 
     log::info!("strip: window {label} built, strip webview added");
 
-    // Frame: first window restores persisted frame / centers, others cascade.
-    if is_first {
+    // Frame: a saved frame (restore) wins; else first window restores the
+    // persisted frame / centers, and others cascade off the host.
+    if let Some([x, y, w, h]) = frame_override.filter(|f| f[2] >= 200 && f[3] >= 200) {
+        let _ = win.set_size(tauri::PhysicalSize::new(w as u32, h as u32));
+        let _ = win.set_position(tauri::PhysicalPosition::new(x as i32, y as i32));
+    } else if is_first {
         if let Some((x, y, w, h)) = prefs::frame_load(app) {
             let _ = win.set_size(tauri::PhysicalSize::new(w, h));
             let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
@@ -179,9 +199,6 @@ pub fn open_browser_window(app: &AppHandle, p: &prefs::Prefs) {
         }
     }
 
-    add_tab(app, &label);
-    log::info!("strip: window {label} ready");
-
     // Show fallback if the first page load never completes.
     {
         let w2 = win.clone();
@@ -192,9 +209,57 @@ pub fn open_browser_window(app: &AppHandle, p: &prefs::Prefs) {
             }
         });
     }
+    Some(label)
 }
 
-/// Add a tab to an existing strip window. Caller must be off the main thread.
+/// Recreate one saved strip window and its tabs (issue #18). Each tab reloads
+/// its saved URL and is re-seeded with its `hermes_profile` cookie so it
+/// reopens on the same profile. Caller must be off the main thread.
+pub fn restore_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
+    if sw.tabs.is_empty() {
+        return;
+    }
+    let p = prefs::load(app);
+    let Some(label) = build_strip_window(app, &p, sw.frame) else {
+        return;
+    };
+    for tab in &sw.tabs {
+        let url = match url::Url::parse(&tab.url) {
+            Ok(u) => u,
+            Err(_) => match url::Url::parse(&p.target_url) {
+                Ok(u) => u,
+                Err(_) => continue,
+            },
+        };
+        // Re-seed only the (non-sensitive) profile selector; fresh jar otherwise.
+        let seed: Vec<Cookie<'static>> = if cfg!(not(target_os = "macos")) {
+            tab.profile
+                .as_deref()
+                .map(|v| vec![crate::session::profile_cookie(v)])
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        add_tab_with(app, &label, url, seed);
+    }
+    // Select the saved active tab.
+    let active_label = {
+        let state = app.state::<AppState>();
+        let strip = state.strip.lock().unwrap();
+        strip
+            .get(&label)
+            .and_then(|e| e.tabs.get(sw.active.min(e.tabs.len().saturating_sub(1))))
+            .map(|t| t.label.clone())
+    };
+    if let Some(al) = active_label {
+        select_tab(app, &label, &al);
+    }
+    log::info!("strip: restored window {label} with {} tab(s)", sw.tabs.len());
+}
+
+/// Add a tab to an existing strip window, seeded from the currently-active
+/// tab's cookie jar so it inherits the active profile + login (issue #3), then
+/// diverges. Caller must be off the main thread (CLAUDE.md invariant #9).
 pub fn add_tab(app: &AppHandle, window_label: &str) {
     let Some(win) = app.windows().get(window_label).cloned() else {
         return;
@@ -212,76 +277,25 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
             return;
         }
     };
-    let allowed_host = target.host_str().map(|h| h.to_lowercase());
 
-    let state = app.state::<AppState>();
-    let (tab_label, opener_label) = {
-        let mut strip = state.strip.lock().unwrap();
-        let Some(entry) = strip.get_mut(window_label) else {
-            return;
-        };
-        // The currently-active tab is the opener we seed the new tab's cookies
-        // from (captured before the new tab is pushed and made active).
-        let opener = entry.tabs.get(entry.active).map(|t| t.label.clone());
-        entry.tab_seq += 1;
-        (
-            format!("tab-{}-{}", window_seq(window_label), entry.tab_seq),
-            opener,
-        )
-    };
-
-    let (r, g, b) = prefs::pre_paint_color(app);
-    let hex = crate::theme::hex_string(r, g, b);
-    // Paint the native webview surface in the cached theme color so a freshly
-    // added tab never flashes white before its first paint. The window-level
-    // anti-flash (build-hidden → reveal on load) can't help here: a new tab is
-    // a child webview of an already-visible window, so it shows immediately
-    // (issue #4). On Windows wry clamps any non-zero alpha to fully opaque,
-    // which is what we want.
-    let to8 = |v: f64| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
-    let bg = Color(to8(r), to8(g), to8(b), 255);
-    // No injected ssh footer in strip mode — status lives in the strip.
-    let init = bridge::init_script(&tab_label, &hex, false);
-
-    // Per-tab cookie isolation (issue #3): the WebUI picks the active profile
-    // via an HttpOnly `hermes_profile` cookie, so a shared cookie jar makes the
-    // profile effectively global — switching profile in one tab bleeds into all
-    // the others. Give each tab its own data partition (separate jar), and seed
-    // it from the opener so a new tab still inherits the current profile + login
-    // (then diverges). Windows/Linux only: WKWebView has no data_directory, and
-    // macOS uses native tabs which this module doesn't drive.
-    let isolate = cfg!(not(target_os = "macos"));
-    let partition = if isolate {
-        tab_partition_dir(app, &tab_label)
-    } else {
-        None
-    };
-    if let Some(ref dir) = partition {
-        // Guarantee a FRESH jar at the point of use. Tab labels are
-        // deterministic and recur every run (window_seq resets to 0 at
-        // startup, so the first tab is always `tab-1-1`), while both the
-        // per-close removal and the startup `clear_partitions` wipe are
-        // best-effort — the OS can hold the WebView2 folder open. If both ever
-        // fail, a same-named tab would otherwise inherit a prior session's
-        // cookies (stale profile/login) instead of opening on the default.
-        // Removing here makes session-scoping hold regardless of cleanup.
-        let _ = std::fs::remove_dir_all(dir);
-        let _ = std::fs::create_dir_all(dir);
-    }
-    // Read the opener's cookies BEFORE the new webview is created. Safe here:
-    // add_tab runs on a worker thread, so Tauri's cookie dispatcher marshals to
-    // the UI thread without the main-thread deadlock the docs warn about.
-    // (`hermes_profile` is HttpOnly, but the native cookie store API sees it.)
+    // Read the active tab's cookies BEFORE the new webview exists — the seed for
+    // the fresh jar. Safe on this worker thread: the cookie dispatcher marshals
+    // to the UI thread without the main-thread deadlock the docs warn about.
     //
-    // Use cookies() (whole store), NOT cookies_for_url(): the latter filters by
-    // URL, and on WKWebView that filter drops host-only cookies entirely — the
-    // WebUI sets `hermes_profile` host-only (no Domain attribute), which is the
-    // macOS inheritance bug (#3). Win/Linux match host-only cookies correctly,
-    // but a content tab only ever loads the one target origin, so its whole
-    // store IS the target's cookies — cookies() is the robust, uniform choice
-    // across all three platforms.
-    let seed: Vec<Cookie<'static>> = if partition.is_some() {
-        match opener_label
+    // cookies() (whole store), NOT cookies_for_url(): WKWebView's URL filter
+    // drops host-only cookies (the WebUI sets `hermes_profile` host-only) — the
+    // macOS inheritance bug (#3). A content tab only ever loads the one target
+    // origin, so its whole store IS that origin's cookies — uniform + robust.
+    let seed: Vec<Cookie<'static>> = if cfg!(not(target_os = "macos")) {
+        let opener = {
+            let state = app.state::<AppState>();
+            let strip = state.strip.lock().unwrap();
+            strip
+                .get(window_label)
+                .and_then(|e| e.tabs.get(e.active))
+                .map(|t| t.label.clone())
+        };
+        match opener
             .and_then(|lbl| find_webview(&win, &lbl))
             .or_else(|| focused_active_webview(app))
         {
@@ -289,24 +303,19 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
                 Ok(cookies) => {
                     let names: Vec<&str> = cookies.iter().map(|c| c.name()).collect();
                     log::info!(
-                        "strip: seeding {tab_label} from opener — {} cookie(s): {:?}",
+                        "strip: seeding new tab in {window_label} from opener — {} cookie(s): {:?}",
                         cookies.len(),
                         names
                     );
                     cookies
                 }
-                // Fail open to the default profile (and re-login if auth) — log
-                // so the multi-profile smoke can tell a seed-read failure apart
-                // from a genuinely empty jar.
                 Err(e) => {
-                    log::warn!(
-                        "strip: seed read failed for {tab_label} (opens on default profile): {e}"
-                    );
+                    log::warn!("strip: seed read failed in {window_label} (opens on default profile): {e}");
                     Vec::new()
                 }
             },
             None => {
-                log::info!("strip: no opener for {tab_label} (opens on default profile)");
+                log::info!("strip: no opener in {window_label} (opens on default profile)");
                 Vec::new()
             }
         }
@@ -314,9 +323,64 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
         Vec::new()
     };
 
-    // When isolating, load about:blank first so cookies can be seeded before
-    // the real navigation — otherwise the first request would race the seed and
-    // the tab would briefly load the wrong profile.
+    add_tab_with(app, window_label, target, seed);
+}
+
+/// Shared tab-creation body: build an isolated content webview for `target`,
+/// seeded with `seed` cookies, append it to `window_label`'s strip and make it
+/// active. Used by `add_tab` (seed = the opener's jar) and session restore
+/// (seed = the saved profile selector). Caller must be off the main thread.
+pub(crate) fn add_tab_with(
+    app: &AppHandle,
+    window_label: &str,
+    target: url::Url,
+    seed: Vec<Cookie<'static>>,
+) {
+    let Some(win) = app.windows().get(window_label).cloned() else {
+        return;
+    };
+    let allowed_host = target.host_str().map(|h| h.to_lowercase());
+    let state = app.state::<AppState>();
+    let tab_label = {
+        let mut strip = state.strip.lock().unwrap();
+        let Some(entry) = strip.get_mut(window_label) else {
+            return;
+        };
+        entry.tab_seq += 1;
+        format!("tab-{}-{}", window_seq(window_label), entry.tab_seq)
+    };
+
+    let (r, g, b) = prefs::pre_paint_color(app);
+    let hex = crate::theme::hex_string(r, g, b);
+    // Paint the native webview surface in the cached theme color so a freshly
+    // added tab never flashes white before its first paint (issue #4). On
+    // Windows wry clamps any non-zero alpha to fully opaque — what we want.
+    let to8 = |v: f64| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+    let bg = Color(to8(r), to8(g), to8(b), 255);
+    // No injected ssh footer in strip mode — status lives in the strip.
+    let init = bridge::init_script(&tab_label, &hex, false);
+
+    // Per-tab cookie isolation (issue #3): each tab gets its own data partition
+    // (separate jar) so the WebUI's HttpOnly `hermes_profile` selector is scoped
+    // to the tab. macOS (HERMES_FORCE_STRIP) has no data_directory → no jar.
+    let partition = if cfg!(not(target_os = "macos")) {
+        tab_partition_dir(app, &tab_label)
+    } else {
+        None
+    };
+    if let Some(ref dir) = partition {
+        // Guarantee a FRESH jar at the point of use — best-effort cleanup
+        // elsewhere can leave a stale folder, and a recurring tab label would
+        // then inherit a prior session's cookies.
+        let _ = std::fs::remove_dir_all(dir);
+        let _ = std::fs::create_dir_all(dir);
+    }
+    // The profile this tab opens on (the seeded `hermes_profile` value, if any)
+    // — shown in the strip's profile dot immediately, before the first real
+    // page load re-reads it (issue #8).
+    let seed_profile = profile_from_cookies(&seed);
+
+    // about:blank first so the seed lands before the real navigation (no race).
     let initial_url = if partition.is_some() {
         WebviewUrl::External(url::Url::parse("about:blank").unwrap())
     } else {
@@ -335,8 +399,7 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
             windows::navigation_allowed(&nav_app, url, allowed_host.as_deref())
         })
         // Native title source — replaces the JS EMIT('title') watcher, which
-        // silently no-ops in remote-origin tab webviews (issue #15). The
-        // webview's label IS the tab label.
+        // silently no-ops in remote-origin tab webviews (issue #15).
         .on_document_title_changed(|wv, title| {
             windows::apply_reported_title(wv.app_handle(), wv.label(), &title);
         })
@@ -360,6 +423,14 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
                     let _ = w.set_focus();
                 }
             }
+            // Re-read this tab's `hermes_profile` cookie after the real load
+            // (the server may have just set/changed it) and refresh the strip's
+            // profile dot (#8) + persist the session (#18). Off the wry callout:
+            // the cookie read marshals via the dispatcher (wry#583 deadlock).
+            let cap_app = app.clone();
+            let cap_win = load_window.clone();
+            let cap_tab = webview.label().to_string();
+            std::thread::spawn(move || capture_tab_profile(&cap_app, &cap_win, &cap_tab));
         });
 
     let (pos, size) = content_bounds(&win);
@@ -371,10 +442,9 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
         }
     };
 
-    // Seed the isolated jar from the opener, then load the real target. The
-    // cookies are committed before the navigation request fires (WebKitGTK's
-    // set_cookie is synchronous; WebView2's AddOrUpdateCookie completes before
-    // navigate), so the first load already carries the inherited profile.
+    // Seed the isolated jar, then load the real target — cookies are committed
+    // before the navigation request fires (set_cookie is synchronous on
+    // WebKitGTK; WebView2's AddOrUpdateCookie completes before navigate).
     if partition.is_some() {
         for cookie in seed {
             let _ = webview.set_cookie(cookie);
@@ -398,6 +468,7 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
             label: tab_label.clone(),
             title: "New Tab".into(),
             attention: false,
+            profile: seed_profile,
         });
         entry.active = entry.tabs.len() - 1;
     }
@@ -405,6 +476,7 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
     log::info!("strip: tab {tab_label} added to {window_label}");
     emit_tabs(app, window_label);
     refresh_window_title(app, window_label);
+    crate::session::persist(app);
 }
 
 pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
@@ -448,6 +520,7 @@ pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
     }
     emit_tabs(app, window_label);
     refresh_window_title(app, window_label);
+    crate::session::persist(app);
 }
 
 pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
@@ -489,6 +562,7 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         select_tab(app, window_label, &next);
     }
     log::info!("strip: closed {tab_label}, {remaining} tabs remain in {window_label}");
+    crate::session::persist(app);
 }
 
 pub fn close_tab_by_label(app: &AppHandle, tab_label: &str) {
@@ -545,6 +619,47 @@ pub fn all_tab_webviews(app: &AppHandle) -> Vec<Webview<Wry>> {
         .flat_map(|w| w.webviews())
         .filter(|wv| wv.label().starts_with("tab-"))
         .collect()
+}
+
+/// Capture every strip window as a session window (issue #18). Each tab's live
+/// URL is read from its webview; order/active/profile come from the registry.
+/// Must run on the main thread (the webview URL getter touches the runtime).
+pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
+    use crate::session::{SessionTab, SessionWindow};
+    let p = prefs::load(app);
+    let state = app.state::<AppState>();
+    let mut out = Vec::new();
+    for win in windows::content_window_handles(app) {
+        let label = win.label().to_string();
+        let (tabs_meta, active) = {
+            let strip = state.strip.lock().unwrap();
+            match strip.get(&label) {
+                Some(e) => (e.tabs.clone(), e.active),
+                None => continue,
+            }
+        };
+        let tabs: Vec<SessionTab> = tabs_meta
+            .iter()
+            .map(|t| {
+                let url = find_webview(&win, &t.label)
+                    .and_then(|wv| crate::session::capture_url(|| wv.url()))
+                    .unwrap_or_else(|| p.target_url.clone());
+                SessionTab {
+                    url,
+                    profile: t.profile.clone(),
+                }
+            })
+            .collect();
+        if tabs.is_empty() {
+            continue;
+        }
+        out.push(SessionWindow {
+            frame: crate::session::frame_of(&win),
+            active: active.min(tabs.len() - 1),
+            tabs,
+        });
+    }
+    out
 }
 
 /// Recompute strip + active tab bounds (window Resized handler).
@@ -615,6 +730,89 @@ pub fn set_tab_title(app: &AppHandle, tab_label: &str, title: &str, attention: b
     }
     emit_tabs(app, &window_label);
     refresh_window_title(app, &window_label);
+}
+
+/// Extract the `hermes_profile` cookie value from a cookie set. `None` means
+/// the default profile (the WebUI sets no such cookie for it).
+pub fn profile_from_cookies(cookies: &[Cookie<'static>]) -> Option<String> {
+    cookies
+        .iter()
+        .find(|c| c.name() == "hermes_profile")
+        .map(|c| c.value().to_string())
+}
+
+/// Read a tab's current profile from its isolated cookie jar; if it changed,
+/// update the registry, repaint the strip (profile dot — #8), and persist the
+/// session (#18). Runs on a worker thread — the cookie read marshals via the
+/// dispatcher, so it must not be called from inside a wry callout (wry#583).
+fn capture_tab_profile(app: &AppHandle, window_label: &str, tab_label: &str) {
+    let Some(win) = app.windows().get(window_label).cloned() else {
+        return;
+    };
+    let Some(wv) = find_webview(&win, tab_label) else {
+        return;
+    };
+    let profile = match wv.cookies() {
+        Ok(cs) => profile_from_cookies(&cs),
+        Err(e) => {
+            log::debug!("strip: profile read failed for {tab_label}: {e}");
+            return;
+        }
+    };
+    let changed = {
+        let state = app.state::<AppState>();
+        let mut strip = state.strip.lock().unwrap();
+        match strip
+            .get_mut(window_label)
+            .and_then(|e| e.tabs.iter_mut().find(|t| t.label == tab_label))
+        {
+            Some(tab) if tab.profile != profile => {
+                tab.profile = profile;
+                true
+            }
+            _ => false,
+        }
+    };
+    if changed {
+        emit_tabs(app, window_label);
+        crate::session::persist(app);
+    }
+}
+
+/// Move a tab to a new index within its window's strip (drag-to-reorder, #19).
+/// The visible webview is unchanged — only the display order and the stored
+/// `Vec` order move; `active` keeps pointing at the same tab label.
+pub fn reorder_tab(app: &AppHandle, window_label: &str, tab_label: &str, new_index: usize) {
+    let state = app.state::<AppState>();
+    let moved = {
+        let mut strip = state.strip.lock().unwrap();
+        let Some(entry) = strip.get_mut(window_label) else {
+            return;
+        };
+        if entry.tabs.is_empty() {
+            return;
+        }
+        let Some(from) = entry.tabs.iter().position(|t| t.label == tab_label) else {
+            return;
+        };
+        let to = new_index.min(entry.tabs.len() - 1);
+        if from == to {
+            return;
+        }
+        let active_label = entry.tabs.get(entry.active).map(|t| t.label.clone());
+        let tab = entry.tabs.remove(from);
+        entry.tabs.insert(to, tab);
+        if let Some(al) = active_label {
+            if let Some(idx) = entry.tabs.iter().position(|t| t.label == al) {
+                entry.active = idx;
+            }
+        }
+        true
+    };
+    if moved {
+        emit_tabs(app, window_label);
+        crate::session::persist(app);
+    }
 }
 
 fn refresh_window_title(app: &AppHandle, window_label: &str) {

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -254,7 +254,10 @@ pub fn restore_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
     if let Some(al) = active_label {
         select_tab(app, &label, &al);
     }
-    log::info!("strip: restored window {label} with {} tab(s)", sw.tabs.len());
+    log::info!(
+        "strip: restored window {label} with {} tab(s)",
+        sw.tabs.len()
+    );
 }
 
 /// Add a tab to an existing strip window, seeded from the currently-active
@@ -299,21 +302,23 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
             .and_then(|lbl| find_webview(&win, &lbl))
             .or_else(|| focused_active_webview(app))
         {
-            Some(opener) => match opener.cookies() {
-                Ok(cookies) => {
-                    let names: Vec<&str> = cookies.iter().map(|c| c.name()).collect();
-                    log::info!(
+            Some(opener) => {
+                match opener.cookies() {
+                    Ok(cookies) => {
+                        let names: Vec<&str> = cookies.iter().map(|c| c.name()).collect();
+                        log::info!(
                         "strip: seeding new tab in {window_label} from opener — {} cookie(s): {:?}",
                         cookies.len(),
                         names
                     );
-                    cookies
+                        cookies
+                    }
+                    Err(e) => {
+                        log::warn!("strip: seed read failed in {window_label} (opens on default profile): {e}");
+                        Vec::new()
+                    }
                 }
-                Err(e) => {
-                    log::warn!("strip: seed read failed in {window_label} (opens on default profile): {e}");
-                    Vec::new()
-                }
-            },
+            }
             None => {
                 log::info!("strip: no opener in {window_label} (opens on default profile)");
                 Vec::new()
@@ -412,6 +417,9 @@ pub(crate) fn add_tab_with(
                 return;
             }
             let app = webview.app_handle().clone();
+            // This tab has a non-nil URL now — capture may read it (#18 crash
+            // guard: never call url() on a not-yet-navigated webview).
+            crate::session::mark_navigated(&app, webview.label());
             let zoom = prefs::zoom_get(&app);
             if (zoom - 1.0).abs() > f64::EPSILON {
                 let _ = webview.set_zoom(zoom);
@@ -554,6 +562,7 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         )
     };
     state.raw_titles.lock().unwrap().remove(tab_label);
+    crate::session::forget_navigated(app, tab_label);
     if let Some(wv) = find_webview(&win, tab_label) {
         let _ = wv.close();
     }
@@ -641,9 +650,16 @@ pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
         let tabs: Vec<SessionTab> = tabs_meta
             .iter()
             .map(|t| {
-                let url = find_webview(&win, &t.label)
-                    .and_then(|wv| crate::session::capture_url(|| wv.url()))
-                    .unwrap_or_else(|| p.target_url.clone());
+                // Only read the live URL once the tab has committed a real
+                // navigation — url() on a not-yet-navigated webview panics on
+                // macOS (and poisons a runtime mutex). Otherwise fall back.
+                let url = if crate::session::has_navigated(app, &t.label) {
+                    find_webview(&win, &t.label)
+                        .and_then(|wv| crate::session::capture_url(|| wv.url()))
+                } else {
+                    None
+                }
+                .unwrap_or_else(|| p.target_url.clone());
                 SessionTab {
                     url,
                     profile: t.profile.clone(),
@@ -882,6 +898,7 @@ pub fn forget_window(app: &AppHandle, window_label: &str) {
         }
         for tab in &entry.tabs {
             remove_tab_partition(app, &tab.label);
+            crate::session::forget_navigated(app, &tab.label);
         }
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -255,6 +255,11 @@ pub fn open_browser(app: &AppHandle, p: &prefs::Prefs, as_tab: bool) -> Option<W
                 .unwrap()
                 .remove(win.label());
             refresh_macos_chrome(&app);
+            // Capture this window's active profile (#8 carrier for #18 restore)
+            // + persist the session. macOS-only; the cookie read is GCD-deferred
+            // inside the helper (invariant #12).
+            #[cfg(target_os = "macos")]
+            capture_window_profile(&app, win.label());
         });
 
     #[cfg(target_os = "macos")]
@@ -410,6 +415,202 @@ pub fn open_browser(app: &AppHandle, p: &prefs::Prefs, as_tab: bool) -> Option<W
             });
         }
     }
+
+    set_offline_badge(app, false);
+    refresh_macos_chrome(app);
+    Some(win)
+}
+
+/// macOS: read this content window's `hermes_profile` cookie and record it in
+/// `window_profiles` (the per-window profile that feeds session capture, #8/#18)
+/// then persist. The cookie read pumps the run loop, so it's GCD-deferred to
+/// run between tao callouts (invariant #12) — never inside a page-load callout.
+#[cfg(target_os = "macos")]
+pub fn capture_window_profile(app: &AppHandle, label: &str) {
+    let Some(win) = app.get_webview_window(label) else {
+        return;
+    };
+    let app = app.clone();
+    let label = label.to_string();
+    crate::macos::run_on_main_async(move || {
+        let profile = win.cookies().ok().and_then(|cs| {
+            cs.into_iter()
+                .find(|c| c.name() == "hermes_profile")
+                .map(|c| c.value().to_string())
+        });
+        {
+            let state = app.state::<AppState>();
+            let mut map = state.window_profiles.lock().unwrap();
+            match profile {
+                Some(v) => {
+                    map.insert(label.clone(), v);
+                }
+                None => {
+                    map.remove(&label);
+                }
+            }
+        }
+        crate::session::persist(&app);
+    });
+}
+
+/// Recreate one saved macOS window-group as native tabs (issue #18). The first
+/// tab is a standalone window; each subsequent tab joins its native tab group
+/// via the freeze-safe `add_tabbed_window` path (invariant #12). Every restored
+/// tab is incognito and re-seeded with its saved `hermes_profile` selector, so
+/// distinct profiles stay isolated and each reopens on the right one (auth
+/// logins are not persisted — an authed server re-prompts). The saved active
+/// tab is focused last. Runs on the orchestrator worker thread.
+#[cfg(target_os = "macos")]
+pub fn restore_macos_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
+    let p = prefs::load(app);
+    let mut group_host: Option<WebviewWindow> = None;
+    let mut built: Vec<WebviewWindow> = Vec::new();
+    for (i, tab) in sw.tabs.iter().enumerate() {
+        let url = match url::Url::parse(&tab.url).or_else(|_| url::Url::parse(&p.target_url)) {
+            Ok(u) => u,
+            Err(_) => continue,
+        };
+        let frame = if i == 0 { sw.frame } else { None };
+        if let Some(win) =
+            build_restored_macos_tab(app, &p, url, tab.profile.clone(), group_host.clone(), frame)
+        {
+            if group_host.is_none() {
+                group_host = Some(win.clone());
+            }
+            built.push(win);
+        }
+    }
+    // Focus the saved active tab once the group has formed (GCD is FIFO, so this
+    // runs after the queued addTabbedWindow blocks).
+    if let Some(active) = built.get(sw.active).or_else(|| built.last()).cloned() {
+        crate::macos::run_on_main_async(move || {
+            let _ = active.set_focus();
+        });
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn build_restored_macos_tab(
+    app: &AppHandle,
+    p: &prefs::Prefs,
+    target: url::Url,
+    profile: Option<String>,
+    host: Option<WebviewWindow>,
+    frame: Option<[i64; 4]>,
+) -> Option<WebviewWindow> {
+    use tauri::TitleBarStyle;
+    let state = app.state::<AppState>();
+    let n = state.window_seq.fetch_add(1, Ordering::SeqCst) + 1;
+    let label = format!("main-{n}");
+    let allowed_host = target.host_str().map(|h| h.to_lowercase());
+    let (r, g, b) = prefs::pre_paint_color(app);
+    let hex = theme::hex_string(r, g, b);
+    let init = bridge::init_script(&label, &hex, p.connection_mode == "ssh");
+
+    let nav_app = app.clone();
+    let load_label = label.clone();
+    let load_mode = p.connection_mode.clone();
+    let load_host = p.ssh_host.clone();
+    let load_port = p.local_port.clone();
+    let seed_target = target.clone();
+
+    let blank = url::Url::parse("about:blank").unwrap();
+    let win = match WebviewWindowBuilder::new(app, &label, WebviewUrl::External(blank))
+        .title("Hermes WebUI")
+        .inner_size(1280.0, 830.0)
+        .theme(Some(cached_theme(app)))
+        .visible(false)
+        .initialization_script(&init)
+        .on_navigation(move |url| navigation_allowed(&nav_app, url, allowed_host.as_deref()))
+        .on_document_title_changed(|win, title| {
+            apply_reported_title(win.app_handle(), win.label(), &title);
+        })
+        .on_page_load(move |webview, payload| {
+            if !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished) {
+                return;
+            }
+            if payload.url().scheme() == "about" {
+                return;
+            }
+            let app = webview.app_handle().clone();
+            let Some(win) = app.get_webview_window(&load_label) else {
+                return;
+            };
+            let zoom = prefs::zoom_get(&app);
+            if (zoom - 1.0).abs() > f64::EPSILON {
+                let _ = win.set_zoom(zoom);
+            }
+            if !win.is_visible().unwrap_or(true) {
+                let _ = win.show();
+                let _ = win.set_focus();
+            }
+            if load_mode == "ssh" {
+                let status = *app.state::<AppState>().tunnel_status.lock().unwrap();
+                push_tunnel_status(&app, &win, status, &load_host, &load_port);
+            }
+            app.state::<AppState>()
+                .ui_state
+                .lock()
+                .unwrap()
+                .remove(win.label());
+            refresh_macos_chrome(&app);
+            capture_window_profile(&app, win.label());
+        })
+        .title_bar_style(TitleBarStyle::Overlay)
+        .hidden_title(true)
+        .tabbing_identifier(TABBING_ID)
+        .incognito(true)
+        .build()
+    {
+        Ok(w) => w,
+        Err(e) => {
+            log::error!("restore: window build failed: {e}");
+            return None;
+        }
+    };
+
+    state
+        .window_modes
+        .lock()
+        .unwrap()
+        .insert(label.clone(), p.connection_mode.clone());
+
+    if let Some([x, y, w, h]) = frame.filter(|f| f[2] >= 200 && f[3] >= 200) {
+        let _ = win.set_size(tauri::PhysicalSize::new(w as u32, h as u32));
+        let _ = win.set_position(tauri::PhysicalPosition::new(x as i32, y as i32));
+    }
+
+    // Subsequent tabs join the group (GCD-deferred — invariant #12).
+    if let Some(host) = &host {
+        crate::macos::add_tabbed_window(host, &win);
+    }
+
+    // Show fallback if the page never finishes loading.
+    {
+        let w2 = win.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(4));
+            if !w2.is_visible().unwrap_or(true) {
+                let _ = w2.show();
+            }
+        });
+    }
+
+    // Seed the profile selector into the (incognito) jar, then navigate to the
+    // saved URL — GCD-deferred so the cookie write's run-loop pump runs outside
+    // tao callouts (invariant #12), after the addTabbedWindow block (FIFO).
+    let new_win = win.clone();
+    crate::macos::run_on_main_async(move || {
+        if let Some(v) = profile {
+            if let Err(e) = new_win.set_cookie(crate::session::profile_cookie(&v)) {
+                log::warn!("restore: set_cookie failed for {}: {e}", new_win.label());
+            }
+        }
+        if let Err(e) = new_win.navigate(seed_target) {
+            log::error!("restore: navigate failed for {}: {e}", new_win.label());
+        }
+    });
 
     set_offline_badge(app, false);
     refresh_macos_chrome(app);

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -151,6 +151,8 @@ pub fn forget(app: &AppHandle, label: &str) {
     let state = app.state::<AppState>();
     state.window_modes.lock().unwrap().remove(label);
     state.raw_titles.lock().unwrap().remove(label);
+    state.window_profiles.lock().unwrap().remove(label);
+    crate::session::forget_navigated(app, label);
 }
 
 /// Open a new browser window (a "tab" on macOS when as_tab and a window
@@ -234,6 +236,8 @@ pub fn open_browser(app: &AppHandle, p: &prefs::Prefs, as_tab: bool) -> Option<W
             let Some(win) = app.get_webview_window(&load_label) else {
                 return;
             };
+            // Non-nil URL now — capture may read it (#18 crash guard).
+            crate::session::mark_navigated(&app, &load_label);
             // Persisted zoom re-applies on every load (Swift didFinish parity).
             let zoom = prefs::zoom_get(&app);
             if (zoom - 1.0).abs() > f64::EPSILON {
@@ -537,6 +541,8 @@ fn build_restored_macos_tab(
             let Some(win) = app.get_webview_window(&load_label) else {
                 return;
             };
+            // Non-nil URL now — capture may read it (#18 crash guard).
+            crate::session::mark_navigated(&app, &load_label);
             let zoom = prefs::zoom_get(&app);
             if (zoom - 1.0).abs() > f64::EPSILON {
                 let _ = win.set_zoom(zoom);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"

--- a/src/shell.html
+++ b/src/shell.html
@@ -72,6 +72,26 @@
       .tab.attention:not(.active) {
         background: rgba(255, 159, 10, 0.12);
       }
+      /* Per-tab profile dot (issue #8): a colored dot keyed to the tab's active
+         WebUI profile, so multiple profiles open at once are tellable apart.
+         Hidden for the default profile (no dot = default). */
+      .tab .pf {
+        flex: none;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+      }
+      /* Drag-to-reorder (issue #19) */
+      .tab.dragging {
+        opacity: 0.45;
+      }
+      .tab.drop-before {
+        box-shadow: inset 2px 0 0 0 var(--hermes-accent, #0a84ff);
+      }
+      .tab.drop-after {
+        box-shadow: inset -2px 0 0 0 var(--hermes-accent, #0a84ff);
+      }
       .tab .x {
         flex: none;
         width: 18px;
@@ -152,6 +172,22 @@
       let boot = { mode: "direct", target: "" };
       let tunnel = null; // {state, host, port}
       let healthy = true;
+      let dragFrom = -1; // index of the tab being dragged (#19)
+      let dragLabel = ""; // label of the tab being dragged
+
+      // Stable-ish color for a profile name → its dot (issue #8). The default
+      // profile (no cookie) gets no dot.
+      function profileColor(name) {
+        let h = 0;
+        for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
+        return "hsl(" + (h % 360) + ", 62%, 55%)";
+      }
+
+      function clearDropMarks() {
+        document
+          .querySelectorAll(".tab.drop-before, .tab.drop-after")
+          .forEach((el) => el.classList.remove("drop-before", "drop-after"));
+      }
 
       function renderTabs(snapshot) {
         if (snapshot.window !== WIN) return;
@@ -163,14 +199,24 @@
             "tab" +
             (i === snapshot.active ? " active" : "") +
             (tab.attention ? " attention" : "");
-          el.title = tab.attention
-            ? (tab.title || "New Tab") + " — waiting for you"
-            : tab.title;
+          el.draggable = true;
+          el.dataset.index = i;
+          const profLabel = tab.profile ? " · profile: " + tab.profile : "";
+          el.title =
+            (tab.attention
+              ? (tab.title || "New Tab") + " — waiting for you"
+              : tab.title || "New Tab") + profLabel;
           if (tab.attention) {
             const dot = document.createElement("span");
             dot.className = "attn";
             dot.setAttribute("aria-label", "waiting for you");
             el.appendChild(dot);
+          } else if (tab.profile) {
+            const pf = document.createElement("span");
+            pf.className = "pf";
+            pf.style.background = profileColor(tab.profile);
+            pf.setAttribute("aria-label", "profile: " + tab.profile);
+            el.appendChild(pf);
           }
           const t = document.createElement("span");
           t.className = "t";
@@ -191,6 +237,43 @@
           el.addEventListener("auxclick", (e) => {
             if (e.button === 1)
               hermes.invoke("tab_close", { window: WIN, tab: tab.label });
+          });
+
+          // Drag-to-reorder (issue #19).
+          el.addEventListener("dragstart", (e) => {
+            dragFrom = i;
+            dragLabel = tab.label;
+            el.classList.add("dragging");
+            if (e.dataTransfer) e.dataTransfer.effectAllowed = "move";
+          });
+          el.addEventListener("dragend", () => {
+            dragFrom = -1;
+            el.classList.remove("dragging");
+            clearDropMarks();
+          });
+          el.addEventListener("dragover", (e) => {
+            if (dragFrom < 0 || dragFrom === i) return;
+            e.preventDefault();
+            if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+            const r = el.getBoundingClientRect();
+            const after = e.clientX > r.left + r.width / 2;
+            el.classList.toggle("drop-after", after);
+            el.classList.toggle("drop-before", !after);
+          });
+          el.addEventListener("dragleave", () =>
+            el.classList.remove("drop-before", "drop-after")
+          );
+          el.addEventListener("drop", (e) => {
+            if (dragFrom < 0 || dragFrom === i) return;
+            e.preventDefault();
+            const r = el.getBoundingClientRect();
+            const after = e.clientX > r.left + r.width / 2;
+            let to = after ? i + 1 : i;
+            if (dragFrom < to) to -= 1; // removal shifts indices left
+            const moved = dragLabel; // the DRAGGED tab, not this drop target
+            clearDropMarks();
+            if (to !== dragFrom && moved)
+              hermes.invoke("tab_reorder", { window: WIN, tab: moved, index: to });
           });
           root.appendChild(el);
         });


### PR DESCRIPTION
A meaty **tabs & sessions** release across macOS, Windows, and Linux. Closes the top of the roadmap's tab-management cluster: **#18, #8, #19, #22**.

## What's in it

### #18 — Restore windows & tabs across restart / in-app update  *(the headline)*
Quit (or auto-update + relaunch) and your workspace comes back: every window's tabs, their order, the active tab, each tab's URL, and each tab's **profile**.
- New `session.rs`: a small `Session { mode, target, windows[] }` blob in `prefs.json`. Capture is deduped (writes only on change), empty-guarded (never clobbers a real session with a transient zero-window moment), and reads on the main thread off a worker.
- **Win/Linux (strip):** `strip::session_windows` / `restore_window`; `add_tab` was split into `add_tab` + `add_tab_with` so restore reuses the exact seed→navigate path.
- **macOS (native tabs):** native `NSWindowTabGroup` is the source of truth (we get no KVO for drag-out/merge/reorder), queried via objc2 (`macos::session_windows`); `windows::restore_macos_window` rebuilds each group through the freeze-safe `add_tabbed_window` (invariant #12). Restored tabs are incognito + re-seeded with their saved profile selector.
- Restore runs **once per launch**, only when the saved session matches the current mode+target.
- **Caveats (documented):** only the non-sensitive `hermes_profile` selector is persisted — never login/auth cookies — so an authenticated server re-prompts after restart; a different server's session isn't restored.

### #8 — Per-tab profile dot (Win/Linux strip)
Each tab shows a color-keyed dot for its active profile (default profile = no dot); hover shows the profile name. Capitalizes on the v0.3.7/v0.3.8 per-tab isolation — `TabEntry` now carries the captured `hermes_profile`.

### #19 — Drag tabs to reorder (Win/Linux strip)
`strip::reorder_tab` + `tab_reorder` command + drag handlers in `shell.html`. The active tab follows its label across the move, and the new order is what gets saved/restored. (macOS reorders via native tabs already.)

### #22 — macOS: can't drag the window with only one tab
Switched window dragging to WebKit-native `-webkit-app-region: drag` on `.app-titlebar` (interactive children marked `no-drag`) instead of Tauri's JS drag region, which no-ops in remote-origin webviews — so it works regardless of tab count. Same remote-IPC family as the #15 title and #12 external-link fixes.

### #5 — deferred (noted in CHANGELOG "Known issues")
The icon's "white fringe" is a light border baked into the artwork; a clean fix needs the source logo + a proper macOS-template icon pass, not pixel surgery on the rendered PNGs.

## Safety / invariants
- **Invariant #12 (Cmd+T freeze):** restore reuses the GCD-deferred `add_tabbed_window`; cookie/URL reads stay outside tao callouts.
- **wry nil-URL panic:** `webview.url()` unwraps a nil `WKWebView.URL` on a not-yet-navigated webview, and capture can race one — guarded by `session::capture_url` (caught + skipped). Found and fixed during local restore testing.
- **Invariant #9:** all window/webview creation stays on worker threads (Win/Linux) / the existing macOS inline path.

## Testing (macOS, against a fake WebUI)
- Native-tab capture → saved `1 window / 2 tabs`; relaunch → `session: restoring 1 window(s), 2 tab(s)` → `tabbed main-2 into main-1`, **no panic**.
- Strip mode (`HERMES_FORCE_STRIP=1`) → restored 2 tabs, then `add_tab` → 3rd tab, **no freeze**.
- Cmd+T heartbeats **8/8**, `windows=2`, no freeze.
- `cargo test` (12, incl. new session serde/cookie tests) + `cargo clippy` clean + Windows `cargo xwin check` green.

Visual checks left for the maintainer on real hardware: the profile dots (#8), drag-to-reorder feel (#19), and single-tab window drag (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)