### PR TITLE
v0.4.1 — macOS window drag (#22): grant start_dragging permission (the real fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.4.1] — 2026-06-17
+
+### Fixed
+
+- **macOS: dragging the window by the title bar with a single tab open now
+  actually works** (issue #22). The v0.4.0 attempt used the CSS
+  `-webkit-app-region: drag`, which is a Chromium/Electron feature that macOS's
+  WebKit webview ignores — so it was a no-op and the window still couldn't be
+  moved. The real cause: the window-drag was driven by Tauri's
+  `data-tauri-drag-region`, but the command it invokes (`start_dragging`) was
+  never permitted for the remote page, so it silently did nothing. The
+  permission is now granted (narrowly — only window dragging, nothing else), and
+  the whole title bar is a drag region (its buttons/links still click). With two
+  or more tabs the native tab bar already provided dragging, which is why the
+  bug only appeared with a single tab.
+
 ## [v0.4.0] — 2026-06-17
 
 A tabs & sessions release across macOS, Windows, and Linux.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.4.0"
+version = "0.4.1"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/capabilities/content.json
+++ b/src-tauri/capabilities/content.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "content-windows",
-  "description": "Minimal IPC for remote hermes-webui content webviews: injected bridge scripts may only emit events",
+  "description": "Minimal IPC for remote hermes-webui content webviews: injected bridge scripts may emit events, plus window-drag so the page titlebar can move the window (issue #22)",
   "windows": ["main-*"],
   "webviews": ["main-*", "tab-*"],
   "remote": {
@@ -17,6 +17,7 @@
     ]
   },
   "permissions": [
-    "core:event:default"
+    "core:event:default",
+    "core:window:allow-start-dragging"
   ]
 }

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -59,20 +59,23 @@ const PASTE_SUPPRESS: &str = r##"
 
 /// S7/S8/S9 — macOS overlay-titlebar integration: traffic-light clearance,
 /// hide the page logo (collides with traffic lights), CSS rule for hiding the
-/// page titlebar when the native tab bar shows, and a NATIVE drag region on
-/// `.app-titlebar`.
+/// page titlebar when the native tab bar shows, and the window drag region.
 ///
-/// Window dragging uses WKWebView's built-in `-webkit-app-region: drag` (the
-/// same mechanism AppKit/Electron use for frameless drag) rather than Tauri's
-/// `data-tauri-drag-region`. The Tauri attribute drives dragging through a
-/// JS→native IPC that is unreliable in remote-origin webviews — the same
-/// remote-IPC fragility that broke titles (#15) and external links (#12) — so
-/// with a single tab (no native tab bar to drag) the window couldn't be moved
-/// at all (issue #22). `-webkit-app-region` is honored natively by WKWebView,
-/// independent of IPC/CSP/capability scope, and works regardless of tab count.
-/// Interactive children are marked `no-drag` so the titlebar's buttons/inputs
-/// still receive clicks. The `data-tauri-drag-region` attribute is kept as a
-/// belt-and-suspenders fallback (harmless when the CSS already handles it).
+/// Window dragging uses Tauri's `data-tauri-drag-region` (Tauri's injected
+/// `drag.js` listens for a mousedown in the region and invokes
+/// `plugin:window|start_dragging`). NOTE: macOS WKWebView does NOT support
+/// Chromium's `-webkit-app-region: drag` despite the prefix — that's an
+/// Electron/Chromium feature, so an earlier attempt using it was a silent
+/// no-op. The Tauri attribute was already present but couldn't move the window
+/// because the remote-content capability granted only `core:event:default`, so
+/// the `start_dragging` command was denied; granting
+/// `core:window:allow-start-dragging` (capabilities/content.json) is what
+/// actually fixes single-tab dragging (issue #22). With 2+ tabs the native tab
+/// bar provided its own drag region, which is why the bug only showed with one.
+///
+/// `deep` makes the entire titlebar a drag region; `drag.js` automatically
+/// exempts interactive descendants (button/a/input/select/[role]/contenteditable
+/// /tabindex), so the titlebar's controls still receive their clicks.
 const MACOS_TITLEBAR: &str = r##"
   try { document.documentElement.style.setProperty('--traffic-light-width', '80px'); } catch (e) {}
   (function () {
@@ -80,11 +83,7 @@ const MACOS_TITLEBAR: &str = r##"
       var s = document.createElement('style');
       s.textContent =
         '.app-titlebar-icon { visibility: hidden !important; } ' +
-        'body.hermes-mac-tabbed .app-titlebar { display: none !important; } ' +
-        '.app-titlebar { -webkit-app-region: drag; } ' +
-        '.app-titlebar button, .app-titlebar a, .app-titlebar input, .app-titlebar select, ' +
-        '.app-titlebar textarea, .app-titlebar [role="button"], .app-titlebar [contenteditable], ' +
-        '.app-titlebar [data-no-drag] { -webkit-app-region: no-drag; }';
+        'body.hermes-mac-tabbed .app-titlebar { display: none !important; }';
       (document.head || document.documentElement).appendChild(s);
     } catch (e) {}
   })();
@@ -92,7 +91,8 @@ const MACOS_TITLEBAR: &str = r##"
     var attach = function () {
       try {
         var tb = document.querySelector('.app-titlebar');
-        if (tb && !tb.hasAttribute('data-tauri-drag-region')) tb.setAttribute('data-tauri-drag-region', '');
+        if (tb && tb.getAttribute('data-tauri-drag-region') !== 'deep')
+          tb.setAttribute('data-tauri-drag-region', 'deep');
       } catch (e) {}
     };
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', attach);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
Follow-up to v0.4.0, which **attempted** #22 but didn't actually fix it.

## What was wrong
The v0.4.0 fix used `-webkit-app-region: drag` — a **Chromium/Electron** feature. macOS **WKWebView ignores it**, so it was a silent no-op and the window still couldn't be dragged with a single tab.

## The real root cause
Dragging is driven by Tauri's `data-tauri-drag-region`, whose handler invokes `plugin:window|start_dragging`. The remote-content capability (`capabilities/content.json`) granted only `core:event:default`, so that command was **denied** and the drag silently did nothing. With 2+ tabs the *native tab bar* supplied its own drag region — which is exactly why the bug only showed with a single tab.

## Fix
- **Grant `core:window:allow-start-dragging`** to the content webviews (narrow — window dragging only; a documented exception to the events-only stance for remote content, invariant #7).
- Set `data-tauri-drag-region="deep"` so the whole titlebar is draggable; Tauri's `drag.js` auto-exempts buttons/links/inputs, so the titlebar controls still click.
- Drop the no-op `-webkit-app-region` CSS.

## Verified
- The generated ACL now permits `start_dragging` for `main-*`/`tab-*`.
- **Confirmed working live on macOS by the maintainer** — single-tab window now drags from the title bar.
- The existing bridge (theme/notifications) already round-trips this same IPC on remote content, so the channel works — only the permission was missing.
- `cargo fmt` / `clippy --all-targets -D warnings` / `cargo test` (12) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
