### PR TITLE
Bug-squash (v0.5.0): file drag #27, restored-tab 502 + login persistence #28, profile dot #26, + rename #7 / hide-bar #10 / what's-new #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [v0.5.0] — 2026-06-17
+
+A bug-squash release focused on things that worked worse than the web, plus tab
+and session fixes and a few tab conveniences.
+
+### Fixed
+
+- **You can drag files from the workspace tree onto the chat composer again**
+  (issue #27, macOS/Windows/Linux). The desktop wrapper left wry's native OS
+  drag-drop handler enabled, which intercepted drag events over the page so the
+  WebUI's own drag-drop never fired — you got the "no-drop" cursor. The handler
+  is now disabled on the content webviews, so in-page drag works **and**
+  dragging a file in from Finder/Explorer drops onto the composer to upload.
+- **Restored tabs no longer come back as `502 Bad Gateway` behind a reverse
+  proxy** (issue #28). On launch the app treated *any* HTTP response — including
+  a proxy's `502`/`503`/`504` while its upstream was still booting — as "ready,"
+  so it reopened your tabs onto gateway-error pages that never recovered.
+  Readiness now rejects those gateway statuses (a real login page / `404` / `405`
+  still counts as up), waits for the server to actually serve, and reloads any
+  tab if the server recovers while the app is open.
+- **Login now survives a restart on Windows/Linux** (issue #28). Each tab's
+  cookie jar is kept on disk and reused when its tab is restored, so you stay
+  logged in across quit/reopen and updates — matching a browser. (Only the jar
+  is reused; nothing sensitive is written to the prefs file. macOS tabs use an
+  isolation model that can't persist, so they still re-prompt for login.)
+- **The per-tab profile dot updates when you switch profile inside a tab**
+  (issue #26, Windows/Linux). It previously only refreshed when a tab was opened
+  or fully reloaded, so an in-tab profile switch left the dot showing the old
+  color; it now re-reads on tab activation and a light periodic sweep, and the
+  first tabs after a re-login get their dots too.
+
+### Added
+
+- **Rename a tab** by double-clicking its title (issue #7, Windows/Linux strip).
+  The name sticks regardless of the page title and is restored across restart;
+  clear it to fall back to the page title.
+- **Hide the tab bar** to reclaim its space (issue #10, Windows) — from the ⋯
+  menu or **Ctrl+Shift+B** (which also brings it back). macOS uses native tabs;
+  Linux is pending an upstream webview-geometry fix.
+- **What's New** in the app menu / ⋯ menu (issue #6) shows the current version
+  and this release's changelog in-app, with a link to the full changelog.
+
 ## [v0.4.1] — 2026-06-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.4.1"
+version = "0.5.0"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/capabilities/shell.json
+++ b/src-tauri/capabilities/shell.json
@@ -2,8 +2,8 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "shell-windows",
   "description": "Full IPC for bundled shell pages (splash, error, preferences, tab strip)",
-  "windows": ["splash", "error", "prefs", "main-*"],
-  "webviews": ["splash", "error", "prefs", "strip-*"],
+  "windows": ["splash", "error", "prefs", "whatsnew", "main-*"],
+  "webviews": ["splash", "error", "prefs", "whatsnew", "strip-*"],
   "permissions": [
     "core:default",
     "store:default",

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -382,6 +382,7 @@ const SHORTCUT_FORWARDER: &str = r##"
     var k = (e.key || '').toLowerCase();
     var send = function (v) { e.preventDefault(); e.stopPropagation(); EMIT('shortcut', v); };
     if (k === 'tab') { send(e.shiftKey ? 'prev-tab' : 'next-tab'); return; }
+    if (k === 'b' && e.shiftKey) { send('toggle-bar'); return; }
     if (e.shiftKey) return;
     if (k === 't') send('new-tab');
     else if (k === 'n') send('new-window');
@@ -564,6 +565,17 @@ pub fn install(app: &AppHandle) {
                         }
                         "next-tab" => crate::strip::cycle_tab(&handle, &label, true),
                         "prev-tab" => crate::strip::cycle_tab(&handle, &label, false),
+                        "toggle-bar" => {
+                            if crate::strip::enabled() && label.starts_with("tab-") {
+                                let app = handle.clone();
+                                let tab = label.clone();
+                                std::thread::spawn(move || {
+                                    if let Some(win) = crate::strip::window_of_tab(&tab) {
+                                        crate::strip::toggle_strip(&app, &win);
+                                    }
+                                });
+                            }
+                        }
                         "prefs" => windows::open_prefs(&handle),
                         "zoom-in" => crate::menu::zoom_step(&handle, 0.1),
                         "zoom-out" => crate::menu::zoom_step(&handle, -0.1),

--- a/src-tauri/src/conn.rs
+++ b/src-tauri/src/conn.rs
@@ -119,14 +119,18 @@ fn run(app: &AppHandle) {
         let rp: u32 = p.remote_port.trim().parse().unwrap_or(8787);
         tunnel::start(app, p.ssh_user.trim(), p.ssh_host.trim(), lp, rp)
     } else {
-        let reachable = health::http_reachable(&p.target_url, Duration::from_secs(4));
-        if !reachable {
+        // Readiness, not mere reachability (issue #28): a proxy answering 502
+        // while its upstream boots must NOT pass, or restore reopens every tab
+        // onto a gateway-error page. http_ready rejects 502/503/504; the
+        // recovery loop below then polls until the upstream really serves.
+        let ready = health::http_ready(&p.target_url, Duration::from_secs(4));
+        if !ready {
             *state.last_error_hint.lock().unwrap() = format!(
-                "Nothing answered at {}. Is hermes-webui running? (./start.sh)",
+                "Nothing is serving at {} yet. Is hermes-webui up? (a proxy may be returning 502/503 while it starts)",
                 p.target_url
             );
         }
-        reachable
+        ready
     };
 
     // The Swift app lingers half a beat so the splash doesn't strobe.
@@ -181,12 +185,20 @@ fn start_health_loop(app: &AppHandle, target: String) {
         if state.health_gen.load(Ordering::SeqCst) != generation {
             return;
         }
-        let healthy = health::http_reachable(&url, Duration::from_secs(5));
+        // Readiness, not reachability: a 502/503/504 from a proxy whose upstream
+        // died counts as DOWN (issue #28), so the badge flips and the recovery
+        // reload below fires — `http_reachable` would have masked it as healthy.
+        let healthy = health::http_ready(&url, Duration::from_secs(5));
         let was = state.healthy.swap(healthy, Ordering::SeqCst);
         if was != healthy {
             log::info!("health: {} -> {}", was, healthy);
             windows::set_offline_badge(&app, !healthy);
             windows::refresh_all_titles(&app);
+            // Recovered (down→up): reload content so any tab stuck on a gateway
+            // error page re-fetches the now-serving app (per-tab 502 recovery).
+            if healthy {
+                windows::eval_all_content(&app, "location.reload();");
+            }
             // Strip pages (Windows/Linux) show the health dot from this event.
             use tauri::Emitter;
             let _ = app.emit("health-changed", serde_json::json!({ "healthy": healthy }));
@@ -209,8 +221,10 @@ fn start_recovery_loop(app: &AppHandle, target: String) {
         if app.get_webview_window("error").is_none() {
             return;
         }
-        if health::http_reachable(&target, Duration::from_secs(3)) {
-            log::info!("recovery: target answered — auto-reconnecting");
+        // Wait for real readiness (2xx/3xx/4xx), not a proxy 502/503/504, before
+        // reconnecting — so restore fires only once the upstream is serving (#28).
+        if health::http_ready(&target, Duration::from_secs(3)) {
+            log::info!("recovery: target serving — auto-reconnecting");
             reconnect(&app);
             return;
         }

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -17,6 +17,30 @@ pub fn http_reachable(url: &str, timeout: Duration) -> bool {
     }
 }
 
+/// Stricter readiness than `http_reachable`, for gating window restore + health
+/// (issue #28). A reverse proxy in front of a still-booting upstream
+/// (Docker/Tailscale/nginx/Cloudflare) answers `502`/`503`/`504`: the
+/// round-trip completes — so `http_reachable` says "up" — but the app isn't
+/// actually serving, so restoring tabs onto it lands them on a gateway error
+/// page that never recovers. Treat those gateway statuses as NOT ready.
+///
+/// Everything else that completes a round-trip still counts as ready, so this
+/// keeps the spirit of invariant #2 (GET, not HEAD; a `401` login page, a
+/// `403`, or a `405` is the server being present): only the
+/// upstream-unavailable gateway codes are rejected. Transport errors = not
+/// ready, as before.
+pub fn http_ready(url: &str, timeout: Duration) -> bool {
+    let agent = ureq::AgentBuilder::new()
+        .timeout_connect(timeout)
+        .timeout(timeout)
+        .build();
+    match agent.get(url).call() {
+        Ok(_) => true,
+        Err(ureq::Error::Status(code, _)) => !matches!(code, 502..=504),
+        Err(_) => false,
+    }
+}
+
 pub fn health_url(target: &str) -> String {
     if target.ends_with('/') {
         format!("{target}health")

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -206,6 +206,10 @@ pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
             tabs.push(SessionTab {
                 url,
                 profile: profiles.get(member.label()).cloned(),
+                // macOS native tabs use incognito stores (no on-disk jar to
+                // reuse) and no custom-title rename surface — both None.
+                partition: None,
+                custom_title: None,
             });
         }
         if tabs.is_empty() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,24 @@ mod windows;
 use state::AppState;
 use tauri::Manager;
 
+/// The shipped changelog, bundled at build time so "What's New" works offline
+/// (issue #6). Repo-root CHANGELOG.md, relative to this file (src-tauri/src/).
+const CHANGELOG_MD: &str = include_str!("../../CHANGELOG.md");
+
+/// Extract the `## [vX.Y.Z]` section body for `version` from the changelog
+/// (everything up to the next `## ` heading). None if absent.
+fn changelog_section(md: &str, version: &str) -> Option<String> {
+    let header = format!("## [v{version}]");
+    let start = md.lines().position(|l| l.starts_with(&header))?;
+    let body: Vec<&str> = md
+        .lines()
+        .skip(start + 1)
+        .take_while(|l| !l.starts_with("## "))
+        .collect();
+    let trimmed = body.join("\n").trim().to_string();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
 #[tauri::command]
 fn get_prefs(app: tauri::AppHandle) -> prefs::Prefs {
     prefs::load(&app)
@@ -55,6 +73,28 @@ fn open_preferences(app: tauri::AppHandle) {
 }
 
 #[tauri::command]
+fn open_whats_new(app: tauri::AppHandle) {
+    windows::open_whats_new(&app);
+}
+
+#[tauri::command]
+fn open_releases_page() {
+    let _ = tauri_plugin_opener::open_url(
+        "https://github.com/hermes-webui/hermes-desktop-rust/releases",
+        None::<&str>,
+    );
+}
+
+/// Current version + this version's changelog section (issue #6).
+#[tauri::command]
+fn whats_new(app: tauri::AppHandle) -> serde_json::Value {
+    let version = app.package_info().version.to_string();
+    let body = changelog_section(CHANGELOG_MD, &version)
+        .unwrap_or_else(|| "Release notes are on the GitHub releases page.".to_string());
+    serde_json::json!({ "version": version, "body": body })
+}
+
+#[tauri::command]
 fn close_prefs(app: tauri::AppHandle) {
     if let Some(w) = app.get_webview_window("prefs") {
         let _ = w.destroy();
@@ -88,6 +128,11 @@ fn tab_close(app: tauri::AppHandle, window: String, tab: String) {
 #[tauri::command]
 fn tab_reorder(app: tauri::AppHandle, window: String, tab: String, index: usize) {
     std::thread::spawn(move || strip::reorder_tab(&app, &window, &tab, index));
+}
+
+#[tauri::command]
+fn tab_rename(app: tauri::AppHandle, window: String, tab: String, name: Option<String>) {
+    std::thread::spawn(move || strip::rename_tab(&app, &window, &tab, name));
 }
 
 #[tauri::command]
@@ -176,6 +221,9 @@ fn main() {
             test_connection,
             retry_connect,
             open_preferences,
+            open_whats_new,
+            whats_new,
+            open_releases_page,
             close_prefs,
             get_boot_info,
             tabs_snapshot,
@@ -183,6 +231,7 @@ fn main() {
             tab_select,
             tab_close,
             tab_reorder,
+            tab_rename,
             new_window_cmd,
             strip_menu
         ])
@@ -249,15 +298,20 @@ fn main() {
                     updater::spawn_check(&update_handle, false);
                 });
             }
-            // Session autosave (issue #18): periodically capture windows/tabs so
-            // a frame move or an SPA navigation (neither of which fires a
-            // structural event) is reflected. Cheap — `persist` writes only when
-            // the captured session differs from the last write.
+            // Session autosave (issue #18) + per-tab profile-dot refresh (#26):
+            // one 4s timer. `persist` captures windows/tabs so a frame move or
+            // SPA navigation (no structural event) is reflected; the profile
+            // sweep re-reads each strip tab's cookie so a profile switched
+            // *inside* a tab (an SPA re-render) repaints its dot. Both are cheap
+            // and only act on a real change.
             {
                 let sess_handle = handle.clone();
                 std::thread::spawn(move || loop {
                     std::thread::sleep(std::time::Duration::from_secs(4));
                     session::persist(&sess_handle);
+                    if strip::enabled() {
+                        strip::recapture_profiles(&sess_handle);
+                    }
                 });
             }
             // Chrome poller — the Tauri stand-in for the Swift app's
@@ -277,6 +331,17 @@ fn main() {
         })
         .on_menu_event(|app, event| match event.id().as_ref() {
             "preferences" => windows::open_prefs(app),
+            "whats_new" => windows::open_whats_new(app),
+            "toggle_strip" => {
+                // Hide/show the tab strip of the focused window (issue #10).
+                // Off-thread: it resizes the content webview.
+                let app = app.clone();
+                std::thread::spawn(move || {
+                    if let Some(w) = windows::focused_or_recent_window_handle(&app) {
+                        strip::toggle_strip(&app, w.label());
+                    }
+                });
+            }
             "new_window" => conn::open_new_session(app, false),
             "new_tab" => conn::open_new_session(app, true),
             "paste" => paste::paste_into_focused(app),
@@ -390,4 +455,18 @@ fn main() {
             }
             _ => {}
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::changelog_section;
+
+    #[test]
+    fn extracts_current_version_section() {
+        let md = "# Changelog\n\n## [v0.5.0] — 2026-06-17\n\n### Fixed\n\n- A real fix\n\n## [v0.4.1] — 2026-06-17\n\n- Older stuff\n";
+        let s = changelog_section(md, "0.5.0").expect("section");
+        assert!(s.contains("A real fix"));
+        assert!(!s.contains("Older stuff"), "must stop at the next heading");
+        assert!(changelog_section(md, "9.9.9").is_none());
+    }
 }

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -9,6 +9,7 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .about(None)
         .separator()
         .item(&MenuItemBuilder::with_id("check_updates", "Check for Updates…").build(app)?)
+        .item(&MenuItemBuilder::with_id("whats_new", "What's New").build(app)?)
         .item(&MenuItemBuilder::with_id("reveal_logs", "Reveal Log File").build(app)?)
         .separator()
         .item(
@@ -129,30 +130,43 @@ pub fn zoom_reset(app: &AppHandle) {
 /// Shortcut hints ride in the item text ("\t" column) rather than real
 /// accelerators so they never double-fire with the injected key forwarder.
 pub fn build_strip_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
+    use tauri::menu::IsMenuItem;
     let version = app.package_info().version.to_string();
     let item = |id: &str, text: &str| MenuItemBuilder::with_id(id, text).build(app);
-    Menu::with_items(
-        app,
-        &[
-            &item("new_tab", "New Tab\tCtrl+T")?,
-            &item("new_window", "New Window\tCtrl+N")?,
-            &PredefinedMenuItem::separator(app)?,
-            &item("reload", "Reload\tCtrl+R")?,
-            &item("find", "Find in Page…\tCtrl+F")?,
-            &PredefinedMenuItem::separator(app)?,
-            &item("zoom_in", "Zoom In\tCtrl+=")?,
-            &item("zoom_out", "Zoom Out\tCtrl+-")?,
-            &item("zoom_reset", "Actual Size\tCtrl+0")?,
-            &PredefinedMenuItem::separator(app)?,
-            &item("preferences", "Preferences…\tCtrl+,")?,
-            &item("open_browser", "Open in Browser")?,
-            &PredefinedMenuItem::separator(app)?,
-            &MenuItemBuilder::with_id("about_version", format!("Hermes WebUI Desktop v{version}"))
-                .enabled(false)
-                .build(app)?,
-            &item("check_updates", "Check for Updates…")?,
-            &item("reveal_logs", "Reveal Log File")?,
-            &item("quit", "Quit")?,
-        ],
-    )
+
+    let mut items: Vec<Box<dyn IsMenuItem<tauri::Wry>>> = Vec::new();
+    items.push(Box::new(item("new_tab", "New Tab\tCtrl+T")?));
+    items.push(Box::new(item("new_window", "New Window\tCtrl+N")?));
+    // Hide the tab bar (issue #10) — not on Linux (GTK child-webview geometry,
+    // constraint #1). The shortcut is in the label since hiding removes this
+    // button, so Ctrl+Shift+B is how you bring the bar back.
+    if !cfg!(target_os = "linux") {
+        items.push(Box::new(item(
+            "toggle_strip",
+            "Hide Tab Bar\tCtrl+Shift+B",
+        )?));
+    }
+    items.push(Box::new(PredefinedMenuItem::separator(app)?));
+    items.push(Box::new(item("reload", "Reload\tCtrl+R")?));
+    items.push(Box::new(item("find", "Find in Page…\tCtrl+F")?));
+    items.push(Box::new(PredefinedMenuItem::separator(app)?));
+    items.push(Box::new(item("zoom_in", "Zoom In\tCtrl+=")?));
+    items.push(Box::new(item("zoom_out", "Zoom Out\tCtrl+-")?));
+    items.push(Box::new(item("zoom_reset", "Actual Size\tCtrl+0")?));
+    items.push(Box::new(PredefinedMenuItem::separator(app)?));
+    items.push(Box::new(item("preferences", "Preferences…\tCtrl+,")?));
+    items.push(Box::new(item("open_browser", "Open in Browser")?));
+    items.push(Box::new(PredefinedMenuItem::separator(app)?));
+    items.push(Box::new(
+        MenuItemBuilder::with_id("about_version", format!("Hermes WebUI Desktop v{version}"))
+            .enabled(false)
+            .build(app)?,
+    ));
+    items.push(Box::new(item("whats_new", "What's New")?));
+    items.push(Box::new(item("check_updates", "Check for Updates…")?));
+    items.push(Box::new(item("reveal_logs", "Reveal Log File")?));
+    items.push(Box::new(item("quit", "Quit")?));
+
+    let refs: Vec<&dyn IsMenuItem<tauri::Wry>> = items.iter().map(|b| b.as_ref()).collect();
+    Menu::with_items(app, &refs)
 }

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -35,6 +35,13 @@ pub struct SessionTab {
     pub url: String,
     #[serde(default)]
     pub profile: Option<String>,
+    /// The tab's on-disk partition dir (Windows/Linux) — reused on restore so
+    /// login/cookies survive (issue #28). Absent for macOS / pre-0.5.0 blobs.
+    #[serde(default)]
+    pub partition: Option<String>,
+    /// User-given tab name (issue #7), restored verbatim.
+    #[serde(default)]
+    pub custom_title: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -174,7 +181,14 @@ pub fn maybe_restore(app: &AppHandle) -> bool {
     let Some(saved) = load(app) else {
         return false;
     };
-    if saved.windows.is_empty() || saved.mode != p.connection_mode || saved.target != p.target_url {
+    // Lenient target match (issue #28 "tabs lost"): a trailing-slash difference
+    // between runs (e.g. a Tailscale URL saved with vs without "/") must not
+    // silently skip restore.
+    let norm = |s: &str| s.trim_end_matches('/').to_string();
+    if saved.windows.is_empty()
+        || saved.mode != p.connection_mode
+        || norm(&saved.target) != norm(&p.target_url)
+    {
         return false;
     }
     // Seed last_session so the first persist() doesn't immediately rewrite an
@@ -288,10 +302,14 @@ mod tests {
                     SessionTab {
                         url: "http://localhost:8787/".into(),
                         profile: None,
+                        partition: Some("tab-1-1".into()),
+                        custom_title: None,
                     },
                     SessionTab {
                         url: "http://localhost:8787/c/42".into(),
                         profile: Some("work".into()),
+                        partition: Some("tab-1-2".into()),
+                        custom_title: Some("My Renamed Tab".into()),
                     },
                 ],
             }],
@@ -301,6 +319,14 @@ mod tests {
         assert_eq!(back.windows[0].active, 1);
         assert_eq!(back.windows[0].frame, Some([10, 20, 1280, 830]));
         assert_eq!(back.windows[0].tabs[1].profile.as_deref(), Some("work"));
+        assert_eq!(
+            back.windows[0].tabs[1].partition.as_deref(),
+            Some("tab-1-2")
+        );
+        assert_eq!(
+            back.windows[0].tabs[1].custom_title.as_deref(),
+            Some("My Renamed Tab")
+        );
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -28,6 +28,15 @@ pub struct TabEntry {
     /// per-tab profile dot (issue #8) and is persisted so a restored tab
     /// reopens on the same profile (issue #18).
     pub profile: Option<String>,
+    /// The on-disk data-partition directory name backing this tab's cookie jar
+    /// (Windows/Linux). Normally the tab label, but a tab restored from a saved
+    /// session reuses its *previous* partition so login + cookies survive the
+    /// restart (issue #28). Not sent to the frontend.
+    #[serde(skip)]
+    pub partition: String,
+    /// A user-given tab name that overrides the page title in the strip
+    /// (issue #7). None = follow the document title.
+    pub custom_title: Option<String>,
 }
 
 /// Per-window tab state for strip mode.
@@ -36,6 +45,11 @@ pub struct WindowTabs {
     pub tabs: Vec<TabEntry>,
     pub active: usize,
     pub tab_seq: u64,
+    /// The tab strip is hidden to reclaim its 38px for content (issue #10).
+    /// Toggled via the strip menu / Ctrl+Shift+B; the content webview then
+    /// fills the whole window. Windows-only (macOS = native tabs; Linux can't
+    /// re-fit GTK child webviews — constraint #1).
+    pub strip_hidden: bool,
 }
 
 pub struct AppState {

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -41,16 +41,56 @@ fn find_webview(win: &Window<Wry>, label: &str) -> Option<Webview<Wry>> {
     win.webviews().into_iter().find(|w| w.label() == label)
 }
 
-fn content_bounds(win: &Window<Wry>) -> (LogicalPosition<f64>, LogicalSize<f64>) {
+fn content_bounds(win: &Window<Wry>, top: f64) -> (LogicalPosition<f64>, LogicalSize<f64>) {
     let scale = win.scale_factor().unwrap_or(1.0);
     let size = win
         .inner_size()
         .map(|s| s.to_logical::<f64>(scale))
         .unwrap_or(LogicalSize::new(1280.0, 830.0));
     (
-        LogicalPosition::new(0.0, STRIP_HEIGHT),
-        LogicalSize::new(size.width, (size.height - STRIP_HEIGHT).max(0.0)),
+        LogicalPosition::new(0.0, top),
+        LogicalSize::new(size.width, (size.height - top).max(0.0)),
     )
+}
+
+/// Whether the strip is hidden for `window_label` (issue #10).
+fn strip_hidden(app: &AppHandle, window_label: &str) -> bool {
+    let state = app.state::<AppState>();
+    let strip = state.strip.lock().unwrap();
+    strip
+        .get(window_label)
+        .map(|e| e.strip_hidden)
+        .unwrap_or(false)
+}
+
+/// Y offset where the content webview begins: 0 when the strip is hidden, else
+/// the strip height.
+fn content_top(app: &AppHandle, window_label: &str) -> f64 {
+    if strip_hidden(app, window_label) {
+        0.0
+    } else {
+        STRIP_HEIGHT
+    }
+}
+
+/// Hide/show the tab strip for `window_label` (issue #10). Windows-only: macOS
+/// uses native tabs (no strip) and Linux can't re-fit GTK child webviews
+/// (constraint #1), so this is a no-op there. Caller should be off the main
+/// thread (it resizes the content webview).
+pub fn toggle_strip(app: &AppHandle, window_label: &str) {
+    if cfg!(target_os = "linux") {
+        log::info!("strip: tab-bar toggle unavailable on Linux (GTK child-webview geometry)");
+        return;
+    }
+    {
+        let state = app.state::<AppState>();
+        let mut strip = state.strip.lock().unwrap();
+        let Some(entry) = strip.get_mut(window_label) else {
+            return;
+        };
+        entry.strip_hidden = !entry.strip_hidden;
+    }
+    layout(app, window_label);
 }
 
 /// Per-tab webview data partition path. Each tab gets its own directory → its
@@ -73,15 +113,28 @@ fn remove_tab_partition(app: &AppHandle, tab_label: &str) {
     }
 }
 
-/// Wipe all tab data partitions. Called once at startup before any tab opens:
-/// partitions are session-scoped (chats live server-side), so orphans from a
-/// prior run or a crash would otherwise accumulate. No-op when none exist.
+/// Wipe ORPHAN tab data partitions at startup (before any tab opens). Keeps the
+/// partitions referenced by the saved session so a restored tab's login +
+/// cookies survive the restart (issue #28); removes the rest — jars from closed
+/// windows, crashes, or pre-0.5.0 session-scoped runs — so they don't pile up.
 pub fn clear_partitions(app: &AppHandle) {
+    let keep: std::collections::HashSet<String> = crate::session::load(app)
+        .map(|s| {
+            s.windows
+                .iter()
+                .flat_map(|w| w.tabs.iter())
+                .filter_map(|t| t.partition.clone())
+                .collect()
+        })
+        .unwrap_or_default();
     if let Ok(base) = app.path().app_local_data_dir() {
         let dir = base.join("tab-partitions");
-        if dir.exists() {
-            if let Err(e) = std::fs::remove_dir_all(&dir) {
-                log::warn!("strip: could not clear tab partitions: {e}");
+        if let Ok(entries) = std::fs::read_dir(&dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if !keep.contains(&name) {
+                    let _ = std::fs::remove_dir_all(entry.path());
+                }
             }
         }
     }
@@ -231,16 +284,29 @@ pub fn restore_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
                 Err(_) => continue,
             },
         };
-        // Re-seed only the (non-sensitive) profile selector; fresh jar otherwise.
-        let seed: Vec<Cookie<'static>> = if cfg!(not(target_os = "macos")) {
-            tab.profile
-                .as_deref()
-                .map(|v| vec![crate::session::profile_cookie(v)])
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
-        add_tab_with(app, &label, url, seed);
+        // With a saved partition, REUSE the on-disk jar (login + cookies persist,
+        // issue #28) — no seed needed. Without one (pre-0.5.0 blob / macOS),
+        // fall back to a fresh jar re-seeded with the profile selector (#18).
+        let seed: Vec<Cookie<'static>> =
+            if tab.partition.is_none() && cfg!(not(target_os = "macos")) {
+                tab.profile
+                    .as_deref()
+                    .map(|v| vec![crate::session::profile_cookie(v)])
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+        add_tab_with(
+            app,
+            &label,
+            TabSpec {
+                target: url,
+                seed,
+                partition_override: tab.partition.clone(),
+                profile_hint: tab.profile.clone(),
+                custom_title: tab.custom_title.clone(),
+            },
+        );
     }
     // Select the saved active tab.
     let active_label = {
@@ -328,19 +394,45 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
         Vec::new()
     };
 
-    add_tab_with(app, window_label, target, seed);
+    add_tab_with(
+        app,
+        window_label,
+        TabSpec {
+            target,
+            seed,
+            partition_override: None,
+            profile_hint: None,
+            custom_title: None,
+        },
+    );
 }
 
-/// Shared tab-creation body: build an isolated content webview for `target`,
-/// seeded with `seed` cookies, append it to `window_label`'s strip and make it
-/// active. Used by `add_tab` (seed = the opener's jar) and session restore
-/// (seed = the saved profile selector). Caller must be off the main thread.
-pub(crate) fn add_tab_with(
-    app: &AppHandle,
-    window_label: &str,
-    target: url::Url,
-    seed: Vec<Cookie<'static>>,
-) {
+/// Inputs to `add_tab_with` so `add_tab` (new tab, opener-seeded fresh jar) and
+/// `restore_window` (saved tab, reused jar) share one creation path.
+pub(crate) struct TabSpec {
+    pub target: url::Url,
+    /// Cookies to seed into a FRESH jar (new tab); empty when reusing a jar.
+    pub seed: Vec<Cookie<'static>>,
+    /// Some = reuse this on-disk partition dir (restore → login/cookies survive,
+    /// issue #28); None = a fresh jar keyed by the new tab label.
+    pub partition_override: Option<String>,
+    /// Initial profile dot before the first load re-reads the cookie (restore).
+    pub profile_hint: Option<String>,
+    /// Restored user-given tab name (issue #7).
+    pub custom_title: Option<String>,
+}
+
+/// Shared tab-creation body: build an isolated content webview, append it to
+/// `window_label`'s strip and make it active. Caller must be off the main
+/// thread.
+pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
+    let TabSpec {
+        target,
+        seed,
+        partition_override,
+        profile_hint,
+        custom_title,
+    } = spec;
     let Some(win) = app.windows().get(window_label).cloned() else {
         return;
     };
@@ -366,27 +458,34 @@ pub(crate) fn add_tab_with(
     let init = bridge::init_script(&tab_label, &hex, false);
 
     // Per-tab cookie isolation (issue #3): each tab gets its own data partition
-    // (separate jar) so the WebUI's HttpOnly `hermes_profile` selector is scoped
-    // to the tab. macOS (HERMES_FORCE_STRIP) has no data_directory → no jar.
+    // (separate jar). A restored tab REUSES its saved partition so login +
+    // cookies survive the restart (issue #28); a new tab gets a fresh jar keyed
+    // by its label. macOS (HERMES_FORCE_STRIP) has no data_directory → no jar.
+    let reuse = partition_override.is_some();
+    let partition_id = partition_override.unwrap_or_else(|| tab_label.clone());
     let partition = if cfg!(not(target_os = "macos")) {
-        tab_partition_dir(app, &tab_label)
+        tab_partition_dir(app, &partition_id)
     } else {
         None
     };
     if let Some(ref dir) = partition {
-        // Guarantee a FRESH jar at the point of use — best-effort cleanup
-        // elsewhere can leave a stale folder, and a recurring tab label would
-        // then inherit a prior session's cookies.
-        let _ = std::fs::remove_dir_all(dir);
-        let _ = std::fs::create_dir_all(dir);
+        if reuse {
+            let _ = std::fs::create_dir_all(dir); // keep the existing jar
+        } else {
+            let _ = std::fs::remove_dir_all(dir); // guarantee a fresh jar
+            let _ = std::fs::create_dir_all(dir);
+        }
     }
-    // The profile this tab opens on (the seeded `hermes_profile` value, if any)
-    // — shown in the strip's profile dot immediately, before the first real
-    // page load re-reads it (issue #8).
-    let seed_profile = profile_from_cookies(&seed);
+    // The profile this tab opens on — a restore hint, else the seed cookie's
+    // value — shown in the strip's profile dot before the first load re-reads it
+    // (issue #8).
+    let seed_profile = profile_hint.or_else(|| profile_from_cookies(&seed));
 
-    // about:blank first so the seed lands before the real navigation (no race).
-    let initial_url = if partition.is_some() {
+    // Seed only a FRESH isolated jar; a reused jar already carries its cookies.
+    let do_seed = partition.is_some() && !reuse && !seed.is_empty();
+    // about:blank first ONLY when seeding (so the cookie lands before the real
+    // navigation); reused / un-isolated tabs load the target directly.
+    let initial_url = if do_seed {
         WebviewUrl::External(url::Url::parse("about:blank").unwrap())
     } else {
         WebviewUrl::External(target.clone())
@@ -394,7 +493,16 @@ pub(crate) fn add_tab_with(
 
     let nav_app = app.clone();
     let load_window = window_label.to_string();
-    let mut wb = WebviewBuilder::new(&tab_label, initial_url).background_color(bg);
+    // Disable wry's native OS drag-drop handler so the WebUI's own HTML5
+    // drag-drop works (issue #27): with it enabled, the native layer intercepts
+    // drag events over the webview and the page never sees `dragstart`/`drop`,
+    // so dragging a workspace-tree item onto the composer shows the OS "no-drop"
+    // cursor and never registers. Off, the page handles in-page drag AND
+    // file-from-Finder drops (→ the WebUI's upload handler). The shell
+    // intercepts no native drops, so nothing is lost.
+    let mut wb = WebviewBuilder::new(&tab_label, initial_url)
+        .background_color(bg)
+        .disable_drag_drop_handler();
     if let Some(ref dir) = partition {
         wb = wb.data_directory(dir.clone());
     }
@@ -441,7 +549,7 @@ pub(crate) fn add_tab_with(
             std::thread::spawn(move || capture_tab_profile(&cap_app, &cap_win, &cap_tab));
         });
 
-    let (pos, size) = content_bounds(&win);
+    let (pos, size) = content_bounds(&win, content_top(app, window_label));
     let webview = match win.add_child(wb, pos, size) {
         Ok(w) => w,
         Err(e) => {
@@ -450,10 +558,10 @@ pub(crate) fn add_tab_with(
         }
     };
 
-    // Seed the isolated jar, then load the real target — cookies are committed
+    // Seed the FRESH jar, then load the real target — cookies are committed
     // before the navigation request fires (set_cookie is synchronous on
     // WebKitGTK; WebView2's AddOrUpdateCookie completes before navigate).
-    if partition.is_some() {
+    if do_seed {
         for cookie in seed {
             let _ = webview.set_cookie(cookie);
         }
@@ -472,11 +580,14 @@ pub(crate) fn add_tab_with(
                 let _ = prev_wv.hide();
             }
         }
+        let title = custom_title.clone().unwrap_or_else(|| "New Tab".into());
         entry.tabs.push(TabEntry {
             label: tab_label.clone(),
-            title: "New Tab".into(),
+            title,
             attention: false,
             profile: seed_profile,
+            partition: partition_id,
+            custom_title,
         });
         entry.active = entry.tabs.len() - 1;
     }
@@ -519,7 +630,7 @@ pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         // webview — it crashes natively (isolated by Linux smoke v3/v5;
         // creation-time bounds render fine). Show/hide alone is safe.
         if !cfg!(target_os = "linux") {
-            let (pos, size) = content_bounds(&win);
+            let (pos, size) = content_bounds(&win, content_top(app, window_label));
             let _ = wv.set_position(pos);
             let _ = wv.set_size(size);
         }
@@ -528,6 +639,9 @@ pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
     }
     emit_tabs(app, window_label);
     refresh_window_title(app, window_label);
+    // Re-read the activated tab's profile — catches a profile switch made inside
+    // it while it was hidden, so the dot is correct on switch-back (issue #26).
+    capture_tab_profile(app, window_label, tab_label);
     crate::session::persist(app);
 }
 
@@ -536,7 +650,7 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         return;
     };
     let state = app.state::<AppState>();
-    let (remaining, next_active) = {
+    let (remaining, next_active, closed_partition) = {
         let mut strip = state.strip.lock().unwrap();
         let Some(entry) = strip.get_mut(window_label) else {
             return;
@@ -550,6 +664,7 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         let Some(idx) = entry.tabs.iter().position(|t| t.label == tab_label) else {
             return;
         };
+        let closed_partition = entry.tabs[idx].partition.clone();
         entry.tabs.remove(idx);
         if entry.active >= entry.tabs.len() {
             entry.active = entry.tabs.len() - 1;
@@ -559,6 +674,7 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         (
             entry.tabs.len(),
             entry.tabs.get(entry.active).map(|t| t.label.clone()),
+            closed_partition,
         )
     };
     state.raw_titles.lock().unwrap().remove(tab_label);
@@ -566,7 +682,9 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
     if let Some(wv) = find_webview(&win, tab_label) {
         let _ = wv.close();
     }
-    remove_tab_partition(app, tab_label);
+    // The user explicitly closed this tab → drop its jar (by partition id, which
+    // for a restored tab differs from the regenerated label).
+    remove_tab_partition(app, &closed_partition);
     if let Some(next) = next_active {
         select_tab(app, window_label, &next);
     }
@@ -663,6 +781,10 @@ pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
                 SessionTab {
                     url,
                     profile: t.profile.clone(),
+                    // Persist the on-disk jar dir so restore reuses it (login
+                    // survives, #28). Empty only on macOS forced-strip (no jar).
+                    partition: (!t.partition.is_empty()).then(|| t.partition.clone()),
+                    custom_title: t.custom_title.clone(),
                 }
             })
             .collect();
@@ -699,10 +821,17 @@ pub fn layout(app: &AppHandle, window_label: &str) {
         logical.width,
         logical.height
     );
+    let hidden = strip_hidden(app, window_label);
     let strip_label = format!("strip-{}", window_seq(window_label));
     if let Some(strip_wv) = find_webview(&win, &strip_label) {
-        let _ = strip_wv.set_position(LogicalPosition::new(0.0, 0.0));
-        let _ = strip_wv.set_size(LogicalSize::new(logical.width, STRIP_HEIGHT));
+        if hidden {
+            // Tab bar hidden (#10) — content reclaims the full window.
+            let _ = strip_wv.hide();
+        } else {
+            let _ = strip_wv.show();
+            let _ = strip_wv.set_position(LogicalPosition::new(0.0, 0.0));
+            let _ = strip_wv.set_size(LogicalSize::new(logical.width, STRIP_HEIGHT));
+        }
     }
     let state = app.state::<AppState>();
     let active = {
@@ -714,7 +843,7 @@ pub fn layout(app: &AppHandle, window_label: &str) {
     };
     if let Some(active) = active {
         if let Some(wv) = find_webview(&win, &active) {
-            let (pos, sz) = content_bounds(&win);
+            let (pos, sz) = content_bounds(&win, if hidden { 0.0 } else { STRIP_HEIGHT });
             let _ = wv.set_position(pos);
             let _ = wv.set_size(sz);
         }
@@ -739,13 +868,54 @@ pub fn set_tab_title(app: &AppHandle, tab_label: &str, title: &str, attention: b
         if let Some(entry) = strip.get_mut(&window_label) {
             if let Some(tab) = entry.tabs.iter_mut().find(|t| t.label == tab_label) {
                 let p = prefs::load(app);
-                tab.title = windows::display_title(title, &p.connection_mode, &p.target_url, true);
+                // A user-renamed tab (#7) keeps its name regardless of the page
+                // title; the page title is still recorded (raw_titles above) so
+                // clearing the rename can fall back to it.
+                if tab.custom_title.is_none() {
+                    tab.title =
+                        windows::display_title(title, &p.connection_mode, &p.target_url, true);
+                }
                 tab.attention = attention;
             }
         }
     }
     emit_tabs(app, &window_label);
     refresh_window_title(app, &window_label);
+}
+
+/// Rename a strip tab (issue #7). `name` = the user's label, or None/empty to
+/// clear it and fall back to the page title. Persisted so it survives restart.
+pub fn rename_tab(app: &AppHandle, window_label: &str, tab_label: &str, name: Option<String>) {
+    let name = name.and_then(|n| {
+        let t = n.trim();
+        (!t.is_empty()).then(|| t.chars().take(60).collect::<String>())
+    });
+    let state = app.state::<AppState>();
+    {
+        let p = prefs::load(app);
+        let raw = state
+            .raw_titles
+            .lock()
+            .unwrap()
+            .get(tab_label)
+            .cloned()
+            .unwrap_or_default();
+        let mut strip = state.strip.lock().unwrap();
+        let Some(tab) = strip
+            .get_mut(window_label)
+            .and_then(|e| e.tabs.iter_mut().find(|t| t.label == tab_label))
+        else {
+            return;
+        };
+        tab.title = match &name {
+            Some(n) => n.clone(),
+            None => windows::display_title(&raw, &p.connection_mode, &p.target_url, true),
+        };
+        tab.custom_title = name;
+    }
+    emit_tabs(app, window_label);
+    refresh_window_title(app, window_label);
+    crate::session::persist(app);
 }
 
 /// Extract the `hermes_profile` cookie value from a cookie set. `None` means
@@ -792,6 +962,27 @@ fn capture_tab_profile(app: &AppHandle, window_label: &str, tab_label: &str) {
     if changed {
         emit_tabs(app, window_label);
         crate::session::persist(app);
+    }
+}
+
+/// Re-read every strip tab's profile cookie and repaint dots that changed
+/// (issue #26). The per-tab dot otherwise only refreshes on open / full reload,
+/// so switching profile *inside* a tab (an SPA re-render, no page load) left it
+/// stale, and the first tabs after a relogin could come up with no dot. A light
+/// periodic sweep plus a re-capture on tab activation covers both without a
+/// WebUI signal. `capture_tab_profile` only emits when a value actually
+/// changed, so this is cheap. Runs on a worker thread (cookie reads marshal).
+pub fn recapture_profiles(app: &AppHandle) {
+    let pairs: Vec<(String, String)> = {
+        let state = app.state::<AppState>();
+        let strip = state.strip.lock().unwrap();
+        strip
+            .iter()
+            .flat_map(|(win, e)| e.tabs.iter().map(move |t| (win.clone(), t.label.clone())))
+            .collect()
+    };
+    for (win, tab) in pairs {
+        capture_tab_profile(app, &win, &tab);
     }
 }
 
@@ -885,7 +1076,11 @@ pub fn emit_tabs(app: &AppHandle, window_label: &str) {
     let _ = app.emit("tabs-changed", snapshot(app, window_label));
 }
 
-/// Window destroyed: drop its registry entries.
+/// Window destroyed: drop its registry entries. NOTE: this does NOT delete the
+/// tabs' data partitions — a Destroyed event also fires on quit, and wiping
+/// then would erase the login/cookies we want to restore (issue #28). Partitions
+/// are removed on explicit tab close (`close_tab`) and orphans are swept at the
+/// next startup (`clear_partitions`), which keeps only session-referenced jars.
 pub fn forget_window(app: &AppHandle, window_label: &str) {
     let state = app.state::<AppState>();
     let removed = state.strip.lock().unwrap().remove(window_label);
@@ -897,7 +1092,6 @@ pub fn forget_window(app: &AppHandle, window_label: &str) {
             }
         }
         for tab in &entry.tabs {
-            remove_tab_partition(app, &tab.label);
             crate::session::forget_navigated(app, &tab.label);
         }
     }

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -37,6 +37,12 @@ fn window_seq(window_label: &str) -> &str {
     window_label.strip_prefix("main-").unwrap_or("0")
 }
 
+/// Numeric tab-sequence suffix of a partition id / tab label like `tab-1-3` → 3
+/// (used to advance `tab_seq` past reused partition names on restore, #28).
+fn partition_suffix(id: &str) -> Option<u64> {
+    id.rsplit('-').next().and_then(|n| n.parse::<u64>().ok())
+}
+
 fn find_webview(win: &Window<Wry>, label: &str) -> Option<Webview<Wry>> {
     win.webviews().into_iter().find(|w| w.label() == label)
 }
@@ -307,6 +313,27 @@ pub fn restore_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
                 custom_title: tab.custom_title.clone(),
             },
         );
+    }
+    // Advance tab_seq past the highest REUSED partition suffix (#28 collision):
+    // tab_seq restarts at 0 each launch, but restored tabs reuse their old
+    // partition names (e.g. `tab-1-3`, with gaps from closed/reordered tabs).
+    // Without this, a later new tab could be labeled `tab-1-3` and its
+    // remove-before-create would wipe the restored tab's live jar — losing its
+    // login and making two tabs share one jar (the #3 bleed). Bumping the
+    // counter past every reused suffix guarantees new tabs get fresh names.
+    {
+        let max_suffix = sw
+            .tabs
+            .iter()
+            .filter_map(|t| t.partition.as_deref())
+            .filter_map(partition_suffix)
+            .max()
+            .unwrap_or(0);
+        let state = app.state::<AppState>();
+        let mut strip = state.strip.lock().unwrap();
+        if let Some(entry) = strip.get_mut(&label) {
+            entry.tab_seq = entry.tab_seq.max(max_suffix);
+        }
     }
     // Select the saved active tab.
     let active_label = {
@@ -1094,5 +1121,20 @@ pub fn forget_window(app: &AppHandle, window_label: &str) {
         for tab in &entry.tabs {
             crate::session::forget_navigated(app, &tab.label);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::partition_suffix;
+
+    #[test]
+    fn parses_partition_suffix() {
+        // restore advances tab_seq past these so new tabs can't reuse a live jar.
+        assert_eq!(partition_suffix("tab-1-3"), Some(3));
+        assert_eq!(partition_suffix("tab-2-17"), Some(17));
+        assert_eq!(partition_suffix("tab-10-0"), Some(0));
+        assert_eq!(partition_suffix("garbage"), None);
+        assert_eq!(partition_suffix(""), None);
     }
 }

--- a/src-tauri/src/tunnel.rs
+++ b/src-tauri/src/tunnel.rs
@@ -105,6 +105,10 @@ pub fn start(app: &AppHandle, user: &str, host: &str, local_port: u32, remote_po
 
     // Readiness: a local TCP connect only proves ssh holds the port — only an
     // HTTP round-trip proves the forward is usable end to end (Swift comment).
+    // Use http_ready (not http_reachable) so a reverse proxy on the remote side
+    // answering 502/503/504 while its upstream boots doesn't count as up — same
+    // gateway-error gate as direct mode, so a tunneled restore waits for the
+    // real server too (issue #28).
     let probe_url = format!("http://127.0.0.1:{local_port}/");
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut connected = false;
@@ -112,7 +116,7 @@ pub fn start(app: &AppHandle, user: &str, host: &str, local_port: u32, remote_po
         if !child_alive(app) {
             break;
         }
-        if health::http_reachable(&probe_url, Duration::from_millis(1500)) {
+        if health::http_ready(&probe_url, Duration::from_millis(1500)) {
             connected = true;
             break;
         }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -210,6 +210,10 @@ pub fn open_browser(app: &AppHandle, p: &prefs::Prefs, as_tab: bool) -> Option<W
     let mut builder = WebviewWindowBuilder::new(app, &label, WebviewUrl::External(initial_url))
         .title("Hermes WebUI")
         .inner_size(1280.0, 830.0)
+        // Let the WebUI's HTML5 drag-drop work (tree→composer drag, file-drop
+        // upload) — wry's native drag-drop handler would otherwise swallow it
+        // (issue #27). The shell intercepts no native drops.
+        .disable_drag_drop_handler()
         // Chrome (titlebar/tab bar) opens in the cached page theme — never
         // the OS appearance (Swift: window.appearance = currentAppearance).
         .theme(Some(cached_theme(app)))
@@ -523,6 +527,8 @@ fn build_restored_macos_tab(
     let win = match WebviewWindowBuilder::new(app, &label, WebviewUrl::External(blank))
         .title("Hermes WebUI")
         .inner_size(1280.0, 830.0)
+        // HTML5 drag-drop (issue #27) — see open_browser.
+        .disable_drag_drop_handler()
         .theme(Some(cached_theme(app)))
         .visible(false)
         .initialization_script(&init)
@@ -980,6 +986,30 @@ pub fn open_prefs(app: &AppHandle) {
             .theme(Some(cached_theme(&app)))
             .center()
             .build();
+    });
+}
+
+/// "What's New" window — version + this release's changelog (issue #6). Built
+/// off the calling thread like the other shell windows (invariant #9).
+pub fn open_whats_new(app: &AppHandle) {
+    if let Some(w) = app.get_webview_window("whatsnew") {
+        let _ = w.show();
+        let _ = w.set_focus();
+        return;
+    }
+    let app = app.clone();
+    std::thread::spawn(move || {
+        if app.get_webview_window("whatsnew").is_some() {
+            return;
+        }
+        let _ =
+            WebviewWindowBuilder::new(&app, "whatsnew", WebviewUrl::App("whatsnew.html".into()))
+                .title("What's New")
+                .inner_size(540.0, 620.0)
+                .resizable(true)
+                .theme(Some(cached_theme(&app)))
+                .center()
+                .build();
     });
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"

--- a/src/shell.html
+++ b/src/shell.html
@@ -56,6 +56,20 @@
         text-overflow: ellipsis;
         font-size: 12px;
       }
+      /* Inline rename input (issue #7) */
+      .tab input.rename {
+        flex: 1;
+        min-width: 0;
+        font: 12px inherit;
+        font-family: inherit;
+        color: var(--hermes-fg);
+        background: var(--hermes-bg);
+        border: 1px solid var(--hermes-accent, #0a84ff);
+        border-radius: 4px;
+        padding: 1px 4px;
+        margin: 0;
+        outline: none;
+      }
       /* Attention dot: a tab whose session has a pending approval/clarify
          popup waiting on the user (issue #14). */
       .tab .attn {
@@ -189,6 +203,46 @@
           .forEach((el) => el.classList.remove("drop-before", "drop-after"));
       }
 
+      // Inline tab rename (issue #7): swap the title span for an input.
+      function startRename(el, titleSpan, tabLabel, current) {
+        if (el.querySelector("input.rename")) return;
+        const input = document.createElement("input");
+        input.className = "rename";
+        input.value = current;
+        el.replaceChild(input, titleSpan);
+        input.focus();
+        input.select();
+        let done = false;
+        const finish = (save) => {
+          if (done) return;
+          done = true;
+          if (save) {
+            // Empty/whitespace clears the custom name (backend reverts to title).
+            hermes.invoke("tab_rename", {
+              window: WIN,
+              tab: tabLabel,
+              name: input.value,
+            });
+            // backend emits tabs-changed → renderTabs rebuilds the strip.
+          } else {
+            hermes.invoke("tabs_snapshot", { window: WIN }).then(renderTabs);
+          }
+        };
+        input.addEventListener("keydown", (e) => {
+          e.stopPropagation();
+          if (e.key === "Enter") {
+            e.preventDefault();
+            finish(true);
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            finish(false);
+          }
+        });
+        input.addEventListener("blur", () => finish(true));
+        input.addEventListener("click", (e) => e.stopPropagation());
+        input.addEventListener("dblclick", (e) => e.stopPropagation());
+      }
+
       function renderTabs(snapshot) {
         if (snapshot.window !== WIN) return;
         const root = document.getElementById("tabs");
@@ -221,6 +275,11 @@
           const t = document.createElement("span");
           t.className = "t";
           t.textContent = tab.title || "New Tab";
+          // Double-click the title to rename the tab (issue #7).
+          t.addEventListener("dblclick", (e) => {
+            e.stopPropagation();
+            startRename(el, t, tab.label, tab.title || "");
+          });
           const x = document.createElement("button");
           x.className = "x";
           x.textContent = "×";

--- a/src/whatsnew.html
+++ b/src/whatsnew.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="shared/shell.css" />
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        background: var(--hermes-bg);
+        color: var(--hermes-fg);
+        font:
+          13px/1.5 -apple-system,
+          system-ui,
+          sans-serif;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        padding: 18px 22px 10px;
+        border-bottom: 1px solid var(--hermes-border);
+      }
+      header h1 {
+        margin: 0;
+        font-size: 16px;
+      }
+      header .ver {
+        color: var(--hermes-fg-secondary);
+        font-size: 12px;
+        margin-top: 2px;
+      }
+      main {
+        padding: 8px 22px 22px;
+        overflow: auto;
+        flex: 1;
+      }
+      main h2 {
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--hermes-fg-secondary);
+        margin: 18px 0 6px;
+      }
+      main ul {
+        margin: 4px 0;
+        padding-left: 20px;
+      }
+      main li {
+        margin: 4px 0;
+      }
+      main p {
+        margin: 6px 0;
+      }
+      main code {
+        background: var(--hermes-control-bg);
+        border-radius: 4px;
+        padding: 1px 5px;
+        font-size: 12px;
+      }
+      footer {
+        padding: 12px 22px;
+        border-top: 1px solid var(--hermes-border);
+        text-align: right;
+      }
+      button {
+        font: inherit;
+        padding: 6px 16px;
+        border-radius: 6px;
+        border: 1px solid var(--hermes-border);
+        background: var(--hermes-control-bg);
+        color: var(--hermes-fg);
+        cursor: pointer;
+      }
+      a {
+        color: var(--hermes-accent, #0a84ff);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>What's New</h1>
+      <div class="ver" id="ver"></div>
+    </header>
+    <main id="notes">Loading…</main>
+    <footer>
+      <button id="full">Full changelog ↗</button>
+    </footer>
+    <script src="shared/shell.js"></script>
+    <script>
+      // Minimal, SAFE markdown → HTML for the changelog section: builds DOM
+      // nodes (no innerHTML of untrusted text) so bundled notes render cleanly
+      // without a markdown dependency. Supports ###/## headings, - bullets,
+      // **bold**, and `code`; everything else is plain text.
+      function inline(parent, text) {
+        // Split on `code` and **bold**, append as text/elements (no raw HTML).
+        const re = /(`[^`]+`|\*\*[^*]+\*\*)/g;
+        let last = 0,
+          m;
+        while ((m = re.exec(text))) {
+          if (m.index > last)
+            parent.appendChild(document.createTextNode(text.slice(last, m.index)));
+          const tok = m[0];
+          if (tok.startsWith("`")) {
+            const c = document.createElement("code");
+            c.textContent = tok.slice(1, -1);
+            parent.appendChild(c);
+          } else {
+            const b = document.createElement("strong");
+            b.textContent = tok.slice(2, -2);
+            parent.appendChild(b);
+          }
+          last = re.lastIndex;
+        }
+        if (last < text.length)
+          parent.appendChild(document.createTextNode(text.slice(last)));
+      }
+
+      function render(md) {
+        const root = document.getElementById("notes");
+        root.textContent = "";
+        let ul = null;
+        md.split("\n").forEach((line) => {
+          const l = line.trim();
+          if (l.startsWith("- ")) {
+            if (!ul) {
+              ul = document.createElement("ul");
+              root.appendChild(ul);
+            }
+            const li = document.createElement("li");
+            inline(li, l.slice(2));
+            ul.appendChild(li);
+            return;
+          }
+          ul = null;
+          if (!l) return;
+          if (l.startsWith("### ") || l.startsWith("## ")) {
+            const h = document.createElement("h2");
+            h.textContent = l.replace(/^#+\s*/, "");
+            root.appendChild(h);
+          } else {
+            const p = document.createElement("p");
+            inline(p, l);
+            root.appendChild(p);
+          }
+        });
+      }
+
+      hermes.invoke("get_boot_info").then((info) => hermes.applyBootTheme(info));
+      hermes.invoke("whats_new").then((info) => {
+        document.getElementById("ver").textContent =
+          "Hermes WebUI Desktop v" + info.version;
+        render(info.body || "");
+      });
+      document.getElementById("full").addEventListener("click", () => {
+        // Open the GitHub releases page in the system browser.
+        hermes.invoke("open_releases_page").catch(() => {});
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
A bug-squash release targeting the things that work **worse than the web**, plus tab/session breakage and a few tab conveniences. Picks up the cluster of issues filed since v0.4.x.

## Bugs (priority order)

### #27 — Drag files from the workspace tree → composer (the headline)
Desktop left wry's **native OS drag-drop handler** enabled, which intercepts drag events over the page so the WebUI's own HTML5 drag-drop never fires (you got the "no-drop" cursor). Disabled it on the content webviews (`strip.rs`, `windows.rs` ×2). Bonus: also restores **Finder/Explorer file-drop-to-upload** (drops now reach the WebUI). The shell intercepts no native drops, so nothing is lost.

### #28 — Restored tabs come back as `502 Bad Gateway` behind a proxy
On launch the app treated *any* HTTP response — including a proxy's `502/503/504` while its upstream booted — as "ready," so restore reopened tabs onto gateway-error pages that never recovered. New `health::http_ready` rejects gateway 5xx (a real `401` login / `404` / `405` still counts as up — refines invariant #2 for *readiness* only); restore waits for the server to actually serve; the health loop treats 5xx as down and reloads content on recovery. Also a lenient `target` match (trailing slash) so a Tailscale URL diff doesn't silently skip restore.

### #28 (login persistence, Windows/Linux)
The "logged out after restart" half of #28. Each tab's on-disk cookie jar is now **reused** when its tab is restored instead of wiped — so login + cookies survive quit/reopen and updates, like a browser. Only the jar is reused; **nothing sensitive is written to prefs**. Partitions are removed on explicit tab close; startup keeps session-referenced jars and sweeps orphans. macOS tabs use incognito (can't persist) and still re-prompt. (`TabEntry.partition` / `SessionTab.partition`; `add_tab` refactored to a `TabSpec`.)

### #26 — Profile dot stale after an in-tab profile switch
It only refreshed on open / full reload, so switching profile *inside* a tab left the old color (and the first tabs after re-login had no dot). Now re-reads on tab activation + a light 4s sweep.

## Enhancements

- **#7 Rename tabs** — double-click the title (Win/Linux strip). Sticks regardless of page title, restored across restart, clears back to the page title.
- **#10 Hide the tab bar** (Windows) — ⋯ menu or **Ctrl+Shift+B** (also brings it back); content fills the window. macOS = native tabs; Linux gated off pending the GTK child-webview geometry fix (constraint #1).
- **#6 In-app version + What's New** — bundled changelog section in a small window + menu items (version was already in the ⋯ menu).

## Already shipped (v0.4.0/v0.4.1), closing alongside
#8 (profile dot), #18 (restore tabs), #19 (drag-reorder), #22 (macOS window drag).

## Verified
- macOS: builds, `cargo fmt`, `clippy --all-targets -D warnings`, `cargo test` (13, incl. new session/changelog tests). Windows `cargo xwin check` clean.
- Strip boots + restores through the refactored `TabSpec`/partition path with **no panic**; readiness **rejects a permanent 502** (error window) and a real server connects; session persists the new `partition`/`custom_title` fields.
- Left for real-hardware/CI confirmation: the actual file-drag on the live WebUI (#27), Win/Linux cookie-jar persistence (#28b is a `data_directory` runtime behavior), and the rename/toggle UX clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
