### PR TITLE
Bug-squash (v0.6.0): Windows ⋯-menu hang #33, deep-session restore #30, profile dot #31, native notifications #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## [v0.6.0] — 2026-06-18
+
+A bug-squash release: a Windows hang blocker, plus restore/notification/profile-dot fixes.
+
+### Fixed
+
+- **Windows: clicking the "⋯" overflow menu no longer hangs the app** (issue #33).
+  The menu was popped synchronously inside the IPC command; on Windows that
+  modal `TrackPopupMenu` loop wedged the WebView2 message pump (AppHangB1) — the
+  menu stuck, the window got stuck always-on-top, and Preferences/Quit stopped
+  working, forcing a kill from Task Manager. The popup now runs on the main
+  event loop so its modal loop pumps normally and the command returns at once.
+- **Reopened tabs come back on the session they were on, not a blank page**
+  (issue #30). Restore replayed the root URL, so each tab returned fresh
+  (session, title, and profile dot all gone). The page now reports its live URL
+  — including in-app (SPA) navigation that `WebView2`/`WKWebView` don't expose
+  through the wrapper — so restore reopens the exact deep-linked session.
+- **The per-tab profile dot updates right after you switch profile** (issue #31,
+  follow-on to #26). The dot is now re-read the moment the page navigates (a
+  profile/session switch), so it paints correctly on a freshly created tab
+  without needing to open another tab, and no longer adopts a sibling tab's
+  color after a session switch.
+
+### Changed
+
+- **Browser notifications now fire as native OS notifications** (issue #32).
+  The embedded webview doesn't implement the Web Notifications API, so the
+  WebUI's notifications (response complete, approval required, clarification
+  needed) silently did nothing. The app now bridges `window.Notification` to
+  native notifications, so they appear in Notification Center / the Windows
+  action center / the Linux notification tray. Honors the app's notifications
+  preference. (Replaces the old DOM-heuristic "response is ready" guess with the
+  WebUI's real, specific notifications.)
+
+
 ## [v0.5.0] — 2026-06-17
 
 A bug-squash release focused on things that worked worse than the web, plus tab

--- a/README.md
+++ b/README.md
@@ -1,18 +1,13 @@
 # Hermes WebUI Desktop
 
-The cross-platform desktop app for [hermes-webui](https://github.com/nesquena/hermes-webui)
-— run your Hermes agent's web UI as a real desktop app on **Windows, Linux, and macOS**,
-with one-time SSH tunnel setup for remote servers, native tabs, theme-matched window
-chrome, clipboard image paste, and background-response notifications.
+The cross-platform desktop app for [hermes-webui](https://github.com/nesquena/hermes-webui) — run your Hermes agent's web UI as a real desktop app on **Windows, Linux, and macOS**, with one-time SSH tunnel setup for remote servers, native tabs, theme-matched window chrome, clipboard image paste, and background-response notifications.
 
 <img width="1466" height="920" alt="image" src="https://github.com/user-attachments/assets/a7b81abc-f053-4e11-b2a4-ca3d4d8d72ea" />
 
-Built with [Tauri 2](https://tauri.app) (system webview + Rust — ~11 MB, no bundled
-browser). It is the cross-platform sibling of
-[hermes-swift-mac](https://github.com/hermes-webui/hermes-swift-mac), rebuilt 1:1 from
-its architecture (see [issue #555](https://github.com/nesquena/hermes-webui/issues/555)).
-On macOS, hermes-swift-mac remains the flagship app; this build exists for Windows and
-Linux users and for anyone who wants identical behavior across all three platforms.
+Built with [Tauri 2](https://tauri.app) (system webview + Rust — ~11 MB, no bundled browser). It is the cross-platform sibling of
+[hermes-swift-mac](https://github.com/hermes-webui/hermes-swift-mac), rebuilt 1:1 from its architecture (see [issue #555](https://github.com/nesquena/hermes-webui/issues/555)).
+
+On macOS, hermes-swift-mac remains the flagship app; this build exists for Windows and Linux users and for anyone who wants identical behavior across all three platforms.
 
 ## Install
 
@@ -33,48 +28,27 @@ The app is a shell — it needs a running
 **1. Local server (same machine, including WSL2 on Windows)**
 Start hermes-webui (`./start.sh`), launch the app — it opens
 `http://localhost:8787` by default. Nothing to configure. WSL2's localhost
-forwarding works out of the box in most setups; if it doesn't, set the Target URL
-(Preferences, `Cmd/Ctrl+,`) to the WSL IP (`hostname -I` inside WSL), or enable
-[mirrored networking](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking).
+forwarding works out of the box in most setups; if it doesn't, set the Target URL (Preferences, `Cmd/Ctrl+,`) to the WSL IP (`hostname -I` inside WSL), or enable [mirrored networking](https://learn.microsoft.com/en-us/windows/wsl/networking#mirrored-mode-networking).
 
 **2. Remote server over SSH (the headline feature)**
 Preferences → Mode: **SSH Tunnel** → enter username, host, and ports → Save &
-Reconnect. The app maintains `ssh -N -L 8787:127.0.0.1:8787 user@host` for you, shows
-live tunnel status in a footer, reconnects on demand, and verifies the forward with a
-real HTTP round-trip. **Key-based SSH auth is required** (there's no terminal for
-password prompts) — make sure `ssh user@host` works without typing a password first
-(`ssh-add` your key; on Windows enable the `ssh-agent` service).
+Reconnect. The app maintains `ssh -N -L 8787:127.0.0.1:8787 user@host` for you, shows live tunnel status in a footer, reconnects on demand, and verifies the forward with a real HTTP round-trip. **Key-based SSH auth is required** (there's no terminal for password prompts) — make sure `ssh user@host` works without typing a password first (`ssh-add` your key; on Windows enable the `ssh-agent` service).
 
 **3. Anything else that serves hermes-webui over http(s)**
 Tailscale IP, reverse proxy, custom port — set it as the Target URL in Direct mode.
 
 ## Features
 
-- **Two connection modes** — Direct (with `/health` monitoring and a ●/○ health
-  indicator) and SSH Tunnel (status footer, reconnect button, actionable error
-  hints parsed from ssh itself).
-- **Tabs & windows** — native macOS tab groups (`Cmd+T`, drag to reorder/detach);
-  a browser-style tab bar on Windows/Linux (`Ctrl+T`, `Ctrl+Tab` cycling,
-  middle-click close, ＋ and ⋯ controls); multi-window everywhere (`Cmd/Ctrl+N`).
-  Tab titles follow your conversation names; every tab is a live session view, so
-  switching tabs never interrupts a streaming response.
-- **Theme-matched chrome** — the window borders/titlebar/tab bar follow the web UI's
-  theme (all 11+ hermes-webui skins), with a cached color so every launch and new
-  tab paints correctly from the first frame. No white flashes.
+- **Two connection modes** — Direct (with `/health` monitoring and a ●/○ health indicator) and SSH Tunnel (status footer, reconnect button, actionable error hints parsed from ssh itself).
+- **Tabs & windows** — native macOS tab groups (`Cmd+T`, drag to reorder/detach); a browser-style tab bar on Windows/Linux (`Ctrl+T`, `Ctrl+Tab` cycling, middle-click close, ＋ and ⋯ controls); multi-window everywhere (`Cmd/Ctrl+N`). Tab titles follow your conversation names; every tab is a live session view, so switching tabs never interrupts a streaming response.
+- **Theme-matched chrome** — the window borders/titlebar/tab bar follow the web UI's theme (all 11+ hermes-webui skins), with a cached color so every launch and new tab paints correctly from the first frame. No white flashes.
 - **Paste images** — `Cmd/Ctrl+V` a screenshot straight into the chat composer.
-- **Background notifications** — get pinged when a long response finishes while
-  you're in another app.
+- **Background notifications** — get pinged when a long response finishes while you're in another app.
 - **Find in page** — `Cmd/Ctrl+F`, `Enter`/`Shift+Enter`, `Esc`.
 - **Summon hotkey** — `Cmd/Ctrl+Shift+H` brings Hermes to front from anywhere.
-- **Safe navigation** — only your Hermes origin loads inside the app; external links
-  open in your browser; `file://` is blocked.
-- **Auto-update** — the app checks GitHub Releases shortly after launch and on
-  "Check for Updates…" (app menu on macOS, ⋯ menu on Windows/Linux), verifies the
-  download against a pinned signing key, installs, and relaunches. Covers the
-  Windows installer builds, the Linux AppImage, and macOS; `.deb` installs are
-  notified to grab the new package manually.
-- **Zoom** (`Cmd/Ctrl` `+`/`−`/`0`, persisted), window frame/fullscreen restore,
-  single-instance.
+- **Safe navigation** — only your Hermes origin loads inside the app; external links open in your browser; `file://` is blocked.
+- **Auto-update** — the app checks GitHub Releases shortly after launch and on "Check for Updates…" (app menu on macOS, ⋯ menu on Windows/Linux), verifies the download against a pinned signing key, installs, and relaunches. Covers the Windows installer builds, the Linux AppImage, and macOS; `.deb` installs are notified to grab the new package manually.
+- **Zoom** (`Cmd/Ctrl` `+`/`−`/`0`, persisted), window frame/fullscreen restore, single-instance.
 
 ## Configuration
 
@@ -99,17 +73,11 @@ Logs (attach to bug reports): `~/Library/Logs/ai.get-hermes.HermesWebUIDesktop/`
 ## Troubleshooting
 
 - **"Can't reach Hermes" on launch** — is hermes-webui running? `curl
-  http://localhost:8787/health` should answer. The app retries automatically every
-  5 s while the error screen is up.
-- **SSH tunnel won't connect** — the error window shows the actual ssh failure
-  (auth, host key, DNS…). Test the exact same thing in a terminal first:
-  `ssh -N -L 8787:127.0.0.1:8787 user@host`, then `curl http://127.0.0.1:8787/health`.
+  http://localhost:8787/health` should answer. The app retries automatically every 5 s while the error screen is up.
+- **SSH tunnel won't connect** — the error window shows the actual ssh failure (auth, host key, DNS…). Test the exact same thing in a terminal first: `ssh -N -L 8787:127.0.0.1:8787 user@host`, then `curl http://127.0.0.1:8787/health`.
 - **WSL2: localhost doesn't reach the server** — see setup note 1 above.
-- **Linux: blank/black window** — usually WebKitGTK + NVIDIA proprietary drivers;
-  launch with `WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Hermes*.AppImage`.
-- **Linux: global hotkey does nothing on Wayland** — Wayland doesn't allow global
-  key grabs; bind a compositor shortcut to launching the app instead (the
-  single-instance guard focuses the running window).
+- **Linux: blank/black window** — usually WebKitGTK + NVIDIA proprietary drivers; launch with `WEBKIT_DISABLE_DMABUF_RENDERER=1 ./Hermes*.AppImage`.
+- **Linux: global hotkey does nothing on Wayland** — Wayland doesn't allow global key grabs; bind a compositor shortcut to launching the app instead (the single-instance guard focuses the running window).
 
 ## Build from source
 
@@ -127,15 +95,7 @@ cd src-tauri && cargo test
 
 ## Architecture (one paragraph)
 
-A small Rust core owns a connection state machine (splash → preflight/tunnel →
-window | error), an ssh child process with HTTP-probe readiness checking and a 10 s
-liveness monitor, and a JSON prefs store. The web UI loads in the system webview
-with a set of injected scripts that bridge the two worlds: a theme reporter (drives
-native chrome appearance), a response-settled detector (drives notifications), a
-synthetic paste/drop injector (clipboard images), a find bar, and a navigation/title
-pipeline. Remote page content is capability-restricted to event emission only — it
-can never call into app commands. Releases are built by GitHub Actions on tags
-(`scripts/release.sh`).
+A small Rust core owns a connection state machine (splash → preflight/tunnel → window | error), an ssh child process with HTTP-probe readiness checking and a 10s liveness monitor, and a JSON prefs store. The web UI loads in the system webview with a set of injected scripts that bridge the two worlds: a theme reporter (drives native chrome appearance), a response-settled detector (drives notifications), a synthetic paste/drop injector (clipboard images), a find bar, and a navigation/title pipeline. Remote page content is capability-restricted to event emission only — it can never call into app commands. Releases are built by GitHub Actions on tags (`scripts/release.sh`).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.5.0"
+version = "0.6.0"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -73,6 +73,25 @@ const NOTIFICATION_SHIM: &str = r##"
       } catch (e) {
         window.Notification = HermesNotification;
       }
+      // The WebUI prefers ServiceWorkerRegistration.showNotification when a SW
+      // is active and only falls back to `new Notification` if that REJECTS.
+      // In an embedded webview the SW path can resolve but display nothing,
+      // swallowing the notification before it reaches the shim above. Route it
+      // through the bridge too so SW-first notifications still fire natively.
+      try {
+        if (window.ServiceWorkerRegistration && ServiceWorkerRegistration.prototype) {
+          ServiceWorkerRegistration.prototype.showNotification = function (title, opts) {
+            opts = opts || {};
+            try {
+              EMIT('notify', {
+                title: String(title == null ? 'Hermes' : title),
+                body: String(opts.body || '')
+              });
+            } catch (e) {}
+            return Promise.resolve();
+          };
+        }
+      } catch (e) {}
     } catch (e) {}
   })();
 "##;

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -30,16 +30,51 @@ const PRE_PAINT: &str = r##"
   } catch (e) {}
 "##;
 
-/// S2 — web Notification stub (native notifications replace web ones).
-const NOTIFICATION_STUB: &str = r##"
-  try {
-    if (window.Notification) {
-      Notification.requestPermission = function (cb) {
-        if (cb) cb('denied');
-        return Promise.resolve('denied');
+/// S2 — Web Notifications shim → native OS notifications (issue #32). Tauri's
+/// webviews don't implement the W3C Notification API (absent on WKWebView,
+/// unsurfaced on WebView2/WebKitGTK), so the WebUI's `new Notification(...)`
+/// calls — response complete, approval required, clarify needed — silently
+/// no-op. This replaces `window.Notification` with a shim that reports through
+/// the bridge to `tauri-plugin-notification`, so they fire natively with the
+/// WebUI's real title/body. Permission is pre-granted so the WebUI takes its
+/// notification path; the shell still gates on the app's notifications pref.
+/// (Replaces the old stub, which forced permission to "denied".)
+const NOTIFICATION_SHIM: &str = r##"
+  (function () {
+    try {
+      function HermesNotification(title, opts) {
+        opts = opts || {};
+        try {
+          EMIT('notify', {
+            title: String(title == null ? 'Hermes' : title),
+            body: String(opts.body || '')
+          });
+        } catch (e) {}
+        this.title = title;
+        this.body = opts.body || '';
+        this.onclick = null;
+        this.onclose = null;
+        this.onerror = null;
+        this.onshow = null;
+      }
+      HermesNotification.permission = 'granted';
+      HermesNotification.requestPermission = function (cb) {
+        if (typeof cb === 'function') cb('granted');
+        return Promise.resolve('granted');
       };
-    }
-  } catch (e) {}
+      HermesNotification.prototype.close = function () {};
+      HermesNotification.prototype.addEventListener = function () {};
+      HermesNotification.prototype.removeEventListener = function () {};
+      HermesNotification.prototype.dispatchEvent = function () { return false; };
+      try {
+        Object.defineProperty(window, 'Notification', {
+          value: HermesNotification, writable: true, configurable: true
+        });
+      } catch (e) {
+        window.Notification = HermesNotification;
+      }
+    } catch (e) {}
+  })();
 "##;
 
 /// S3 — Web Speech suppression → webui falls back to MediaRecorder + /api/transcribe.
@@ -198,36 +233,11 @@ const THEME_BRIDGE: &str = r##"
   })();
 "##;
 
-/// S4 — response-ready notifier: characterData-only mutations, ≥20 chars,
-/// 3s settle, fires only while hidden.
-const NOTIFY_WATCHER: &str = r##"
-  (function () {
-    var startObs = function () {
-      if (!document.body) return;
-      let debounceTimer = null;
-      let totalCharsAdded = 0;
-      const MIN_CHARS = 20;
-      const observer = new MutationObserver((mutations) => {
-        let chars = 0;
-        for (const m of mutations) {
-          if (m.type === 'characterData') chars += (m.target.nodeValue || '').length;
-        }
-        if (chars === 0) return;
-        totalCharsAdded += chars;
-        clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(() => {
-          if (document.hidden && totalCharsAdded >= MIN_CHARS) {
-            EMIT('notify', { title: 'Hermes', body: 'Your response is ready' });
-          }
-          totalCharsAdded = 0;
-        }, 3000);
-      });
-      observer.observe(document.body, { subtree: true, characterData: true });
-    };
-    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', startObs);
-    else startObs();
-  })();
-"##;
+// S4 — the old DOM-mutation "response is ready" heuristic was removed in favor
+// of the Notification shim (issue #32): the WebUI now fires precise native
+// notifications (response complete / approval / clarify) through window.
+// Notification → EMIT('notify'), so the crude ≥20-chars-while-hidden watcher
+// would only double-fire. (Removed; the shim is the single notification path.)
 
 /// S11 — window.open / target=_blank: same-origin navigates, external opens
 /// in the system browser (parity-plus; the Swift app drops these silently).
@@ -431,9 +441,41 @@ const DOWNLOAD_BRIDGE: &str = r##"
   }, true);
 "##;
 
+/// S14 — route reporter (issue #30): report the page's live `location.href`
+/// (including client-side `pushState`/hash routes) to the shell so session
+/// restore can reopen the exact deep-linked session, not just the root. wry's
+/// `url()` doesn't reliably reflect SPA history changes on every engine
+/// (notably WebView2), so the page reports the URL itself, debounced to fire
+/// only when it actually changes.
+const ROUTE_REPORTER: &str = r##"
+  (function () {
+    var last = '';
+    var report = function () {
+      try {
+        var h = location.href;
+        if (h && h !== last) { last = h; EMIT('route', h); }
+      } catch (e) {}
+    };
+    var wrap = function (name) {
+      try {
+        var orig = history[name];
+        if (typeof orig === 'function') {
+          history[name] = function () { var r = orig.apply(this, arguments); report(); return r; };
+        }
+      } catch (e) {}
+    };
+    wrap('pushState'); wrap('replaceState');
+    window.addEventListener('popstate', report);
+    window.addEventListener('hashchange', report);
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', report);
+    else report();
+    setInterval(report, 2000);
+  })();
+"##;
+
 /// Assemble the per-window initialization script.
 pub fn init_script(label: &str, pre_paint_hex: &str, is_ssh: bool) -> String {
-    let mut parts: Vec<&str> = vec![HELPER, PRE_PAINT, NOTIFICATION_STUB, SPEECH_SUPPRESS];
+    let mut parts: Vec<&str> = vec![HELPER, PRE_PAINT, NOTIFICATION_SHIM, SPEECH_SUPPRESS];
     if cfg!(any(target_os = "macos", target_os = "linux")) {
         parts.push(PASTE_SUPPRESS);
     }
@@ -444,7 +486,7 @@ pub fn init_script(label: &str, pre_paint_hex: &str, is_ssh: bool) -> String {
         parts.push(SHORTCUT_FORWARDER);
     }
     parts.push(THEME_BRIDGE);
-    parts.push(NOTIFY_WATCHER);
+    parts.push(ROUTE_REPORTER);
     parts.push(WINDOW_OPEN);
     parts.push(FIND_BAR);
     if cfg!(any(target_os = "macos", target_os = "linux")) {
@@ -488,6 +530,20 @@ pub fn install(app: &AppHandle) {
             "theme" => {
                 if let Some(css) = payload["value"].as_str() {
                     handle_theme_report(&handle, css);
+                }
+            }
+            // Live URL incl. SPA routes (issue #30) — the authoritative per-tab
+            // URL for session restore. Also a fast signal that the page
+            // navigated (profile/session switch), so re-read the profile dot
+            // now instead of waiting for the periodic sweep (issue #31).
+            "route" => {
+                if let Some(u) = payload["value"].as_str() {
+                    crate::session::report_url(&handle, &label, u);
+                }
+                if crate::strip::enabled() && label.starts_with("tab-") {
+                    let app = handle.clone();
+                    let tab = label.clone();
+                    std::thread::spawn(move || crate::strip::recapture_tab_profile(&app, &tab));
                 }
             }
             "notify" => {

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -191,15 +191,20 @@ pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
             let Some(member) = by_ptr.get(ptr) else {
                 continue;
             };
-            // Only read the live URL once the window has committed a real
-            // navigation — url() on a not-yet-navigated WKWebView unwraps a nil
-            // NSURL and panics (poisoning a runtime mutex → SIGABRT).
-            let url = if crate::session::has_navigated(app, member.label()) {
-                crate::session::capture_url(|| member.url())
-            } else {
-                None
-            }
-            .unwrap_or_else(|| target.clone());
+            // Prefer the page-reported live URL (captures SPA routes, #30); fall
+            // back to wry's url() only once navigated (it panics on a
+            // not-yet-navigated WKWebView, poisoning a runtime mutex → SIGABRT),
+            // then to root.
+            let url = crate::session::reported_url(app, member.label())
+                .filter(|u| !u.starts_with("about:"))
+                .or_else(|| {
+                    if crate::session::has_navigated(app, member.label()) {
+                        crate::session::capture_url(|| member.url())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| target.clone());
             if Some(i) == selected {
                 active = tabs.len();
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -148,6 +148,13 @@ fn strip_menu(app: tauri::AppHandle, window: String) {
     // WebView2 message pump → the menu sticks, the window gets stuck topmost,
     // and Preferences/Quit stop firing (AppHangB1). Marshaled onto the event
     // loop, the modal loop pumps normally and the command returns immediately.
+    //
+    // `run_on_main_thread` (not the GCD `dispatch_main_async` of invariant #12)
+    // is fine because the strip — and thus this command — is Windows/Linux only
+    // (macOS uses native tabs; it's reachable on macOS only via the dev
+    // HERMES_FORCE_STRIP). A context-menu popup doesn't force a window redraw
+    // the way addTabbedWindow does, so there's no draw_rect re-entrancy here. If
+    // the strip ever ships on macOS, route this popup through dispatch_main_async.
     let _ = app.clone().run_on_main_thread(move || {
         use tauri::menu::ContextMenu;
         let Some(win) = app.windows().get(&window).cloned() else {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -142,13 +142,21 @@ fn new_window_cmd(app: tauri::AppHandle) {
 
 #[tauri::command]
 fn strip_menu(app: tauri::AppHandle, window: String) {
-    use tauri::menu::ContextMenu;
-    let Some(win) = app.windows().get(&window).cloned() else {
-        return;
-    };
-    if let Ok(menu) = menu::build_strip_menu(&app) {
-        let _ = menu.popup(win);
-    }
+    // Pop the "⋯" menu on the MAIN event-loop thread, not inline in this IPC
+    // command (issue #33). On Windows `Menu::popup` enters a modal
+    // `TrackPopupMenu` loop; running it from the IPC command thread wedges the
+    // WebView2 message pump → the menu sticks, the window gets stuck topmost,
+    // and Preferences/Quit stop firing (AppHangB1). Marshaled onto the event
+    // loop, the modal loop pumps normally and the command returns immediately.
+    let _ = app.clone().run_on_main_thread(move || {
+        use tauri::menu::ContextMenu;
+        let Some(win) = app.windows().get(&window).cloned() else {
+            return;
+        };
+        if let Ok(menu) = menu::build_strip_menu(&app) {
+            let _ = menu.popup(win);
+        }
+    });
 }
 
 #[tauri::command]

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -256,6 +256,38 @@ pub fn forget_navigated(app: &AppHandle, label: &str) {
         .remove(label);
 }
 
+/// Record the page's live URL reported by the injected route reporter (#30).
+/// Ignores `about:`/non-http so a pre-seed blank never overwrites a real route.
+pub fn report_url(app: &AppHandle, label: &str, url: &str) {
+    if !url.starts_with("http") {
+        return;
+    }
+    app.state::<AppState>()
+        .tab_urls
+        .lock()
+        .unwrap()
+        .insert(label.to_string(), url.to_string());
+}
+
+/// The page-reported live URL for `label`, if any (the deep session route).
+pub fn reported_url(app: &AppHandle, label: &str) -> Option<String> {
+    app.state::<AppState>()
+        .tab_urls
+        .lock()
+        .unwrap()
+        .get(label)
+        .cloned()
+}
+
+/// Drop a closed webview/window from the reported-URL map.
+pub fn forget_url(app: &AppHandle, label: &str) {
+    app.state::<AppState>()
+        .tab_urls
+        .lock()
+        .unwrap()
+        .remove(label);
+}
+
 /// Read a webview's current URL, tolerating the engine not having set one yet.
 /// wry's `url()` unwraps the native URL (nil for a freshly-created, not-yet-
 /// navigated webview) and panics — and capture can race a just-opened tab — so

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -67,6 +67,12 @@ pub struct AppState {
     pub window_modes: Mutex<HashMap<String, String>>,
     /// label -> last raw document.title reported by the title-watcher script.
     pub raw_titles: Mutex<HashMap<String, String>>,
+    /// label -> the page's live `location.href`, reported by the injected route
+    /// reporter. This is the authoritative per-tab URL for session restore
+    /// (issue #30): wry's `url()` doesn't reliably reflect client-side
+    /// `pushState` routing (notably WebView2), so the page reports it directly
+    /// and capture prefers this over `url()`.
+    pub tab_urls: Mutex<HashMap<String, String>>,
     /// label -> (tab_bar_visible, fullscreen) — last chrome state pushed into
     /// the page (hermes-mac-tabbed class, --traffic-light-width). macOS only.
     pub ui_state: Mutex<HashMap<String, (bool, bool)>>,
@@ -117,6 +123,7 @@ impl AppState {
             healthy: AtomicBool::new(true),
             window_modes: Mutex::new(HashMap::new()),
             raw_titles: Mutex::new(HashMap::new()),
+            tab_urls: Mutex::new(HashMap::new()),
             ui_state: Mutex::new(HashMap::new()),
             strip: Mutex::new(HashMap::new()),
             window_profiles: Mutex::new(HashMap::new()),

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -706,6 +706,7 @@ pub fn close_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
     };
     state.raw_titles.lock().unwrap().remove(tab_label);
     crate::session::forget_navigated(app, tab_label);
+    crate::session::forget_url(app, tab_label);
     if let Some(wv) = find_webview(&win, tab_label) {
         let _ = wv.close();
     }
@@ -795,16 +796,20 @@ pub fn session_windows(app: &AppHandle) -> Vec<crate::session::SessionWindow> {
         let tabs: Vec<SessionTab> = tabs_meta
             .iter()
             .map(|t| {
-                // Only read the live URL once the tab has committed a real
-                // navigation — url() on a not-yet-navigated webview panics on
-                // macOS (and poisons a runtime mutex). Otherwise fall back.
-                let url = if crate::session::has_navigated(app, &t.label) {
-                    find_webview(&win, &t.label)
-                        .and_then(|wv| crate::session::capture_url(|| wv.url()))
-                } else {
-                    None
-                }
-                .unwrap_or_else(|| p.target_url.clone());
+                // Prefer the page-reported live URL (captures SPA routes, #30).
+                // Fall back to wry's url() only once the tab has navigated (it
+                // panics on a not-yet-navigated webview on macOS), then to root.
+                let url = crate::session::reported_url(app, &t.label)
+                    .filter(|u| !u.starts_with("about:"))
+                    .or_else(|| {
+                        if crate::session::has_navigated(app, &t.label) {
+                            find_webview(&win, &t.label)
+                                .and_then(|wv| crate::session::capture_url(|| wv.url()))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| p.target_url.clone());
                 SessionTab {
                     url,
                     profile: t.profile.clone(),
@@ -1013,6 +1018,16 @@ pub fn recapture_profiles(app: &AppHandle) {
     }
 }
 
+/// Re-read one tab's profile immediately. Called from the route reporter
+/// (issue #31): a profile/session switch navigates the page, so re-capturing on
+/// the route change repaints the dot at once — without waiting for the periodic
+/// sweep or needing another tab to open. Caller must be off the main thread.
+pub fn recapture_tab_profile(app: &AppHandle, tab_label: &str) {
+    if let Some(window_label) = window_of_tab(tab_label) {
+        capture_tab_profile(app, &window_label, tab_label);
+    }
+}
+
 /// Move a tab to a new index within its window's strip (drag-to-reorder, #19).
 /// The visible webview is unchanged — only the display order and the stored
 /// `Vec` order move; `active` keeps pointing at the same tab label.
@@ -1120,6 +1135,7 @@ pub fn forget_window(app: &AppHandle, window_label: &str) {
         }
         for tab in &entry.tabs {
             crate::session::forget_navigated(app, &tab.label);
+            crate::session::forget_url(app, &tab.label);
         }
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -153,6 +153,7 @@ pub fn forget(app: &AppHandle, label: &str) {
     state.raw_titles.lock().unwrap().remove(label);
     state.window_profiles.lock().unwrap().remove(label);
     crate::session::forget_navigated(app, label);
+    crate::session::forget_url(app, label);
 }
 
 /// Open a new browser window (a "tab" on macOS when as_tab and a window

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
A bug-squash release grabbing the cluster filed since v0.5.0 — including a Windows hang blocker.

## #33 — Windows: clicking the "⋯" menu hangs the app *(blocker)*
The strip menu was popped **synchronously inside the IPC command**, so on Windows the modal `TrackPopupMenu` loop wedged the WebView2 message pump (`AppHangB1`): the menu stuck, the window got stuck always-on-top, and Preferences/Quit stopped firing — only a Task Manager kill recovered it. `strip_menu` now marshals the popup onto the **main event loop** (`run_on_main_thread`) so its modal loop pumps normally and the command returns immediately. (This was the one remaining main-thread-blocking IPC command — the off-thread invariant #9 now covers it.)

## #30 — Restore was shallow (tabs came back blank)
Reopened tabs preserved only the **count** — each came back fresh (session, title, profile dot gone). Root cause: `webview.url()` doesn't reliably reflect the WebUI's in-app (SPA `pushState`) routing — notably on WebView2 — so restore replayed the **root** URL. Fix: a route reporter has the page `EMIT` its live `location.href`; `AppState.tab_urls` stores it; session capture prefers it over `url()`.

**Verified end-to-end on macOS:** capture saved `…/c/sess-abc?notif=true` (the deep route, not root), and on relaunch the server received `GET /c/sess-abc?notif=true` — the tab reopened on its exact session.

## #31 — Profile dot missing on create / wrong color after a session switch
Follow-on to #26. The dot is now re-read the moment the page navigates (a profile/session switch reports a route), via `recapture_tab_profile` — so it paints on a freshly created tab without needing to open another, and stops adopting a sibling tab's color after a session switch. Combines with the existing `select_tab` + 4s sweep capture paths.

## #32 — Browser notifications now fire natively
The embedded webview has no Web Notifications API, so the WebUI's notifications (response complete / approval required / clarification needed) silently no-op'd. Replaced the old permission-`denied` stub with a `window.Notification` **shim** that routes through the bridge to `tauri-plugin-notification` — so they appear in Notification Center / Windows action center / Linux tray. Honors the app's notifications pref. (Also removed the old crude DOM-mutation "response is ready" guess — the shim delivers the WebUI's real, specific notifications.)

**Verified:** `notif=true` round-tripped through the shimmed page (`'Notification' in window && permission === 'granted'`), and `new Notification(...)` reached the native bridge.

## Verification
- macOS: builds, `cargo fmt`, `clippy --all-targets -D warnings`, `cargo test` (14). Windows `cargo xwin check` clean.
- #30 + #32 verified live on macOS (forced-strip). #31's recapture fires on the proven route signal. #33 is a clean Windows-specific fix — **please field-verify on Windows** that the ⋯ menu opens/closes and the window stays interactable (Preferences/Quit fire) afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
