### PR TITLE
fix: strip ⋯ menu hang on Windows (AppHangB1) from 4s timer webview marshal (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v0.6.0] — 2026-06-18
+
+A focused fix for a Windows hang when opening the tab strip's "⋯" menu.
+
+### Fixed
+
+- **The "⋯" overflow menu no longer hangs the app on Windows** (issue #33). A
+  few seconds after opening the strip's "⋯" menu the app would freeze: the menu
+  became unresponsive, the window got stuck on top of everything else, and
+  Preferences/Quit stopped working — you had to kill it from Task Manager
+  (Windows logged it as `AppHangB1`). The native menu runs a modal loop on the
+  main thread; meanwhile a periodic 4-second timer (session autosave + the
+  per-tab profile-dot refresh) reads each tab's cookie/URL, and those reads
+  marshal back onto the main thread. With the menu's modal loop already holding
+  the main thread, that re-entry deadlocked the UI. The timer now skips its
+  webview reads while a menu is open and catches up on the next tick once it
+  closes, so the menu stays responsive and nothing freezes.
+
 ## [v0.5.0] — 2026-06-17
 
 A bug-squash release focused on things that worked worse than the web, plus tab

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.5.0"
+version = "0.6.0"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -142,13 +142,29 @@ fn new_window_cmd(app: tauri::AppHandle) {
 
 #[tauri::command]
 fn strip_menu(app: tauri::AppHandle, window: String) {
+    use std::sync::atomic::Ordering;
     use tauri::menu::ContextMenu;
     let Some(win) = app.windows().get(&window).cloned() else {
         return;
     };
-    if let Ok(menu) = menu::build_strip_menu(&app) {
-        let _ = menu.popup(win);
-    }
+    let Ok(menu) = menu::build_strip_menu(&app) else {
+        return;
+    };
+    // This sync command runs on the MAIN THREAD, so `popup` correctly drives the
+    // native modal loop (Windows `TrackPopupMenu`) here. The hang (issue #33)
+    // wasn't the popup itself — the menu opens fine — it was the periodic
+    // autosave + profile-dot timer firing ~2-3s later and marshaling into the
+    // webviews (cookie/URL getters) WHILE this modal loop owns the main thread:
+    // that re-enters the main thread from inside the modal loop, which WebView2
+    // forbids → AppHangB1 (frozen menu, window stuck topmost, Preferences/Quit
+    // dead). Flag `menu_open` for the duration so that worker tick skips its
+    // webview work and catches up on the next tick once the menu closes.
+    // `popup` blocks until the menu is dismissed on Windows; on macOS/Linux it
+    // returns immediately, so the flag is naturally short-lived there.
+    let state = app.state::<AppState>();
+    state.menu_open.store(true, Ordering::SeqCst);
+    let _ = menu.popup(win);
+    state.menu_open.store(false, Ordering::SeqCst);
 }
 
 #[tauri::command]
@@ -308,6 +324,21 @@ fn main() {
                 let sess_handle = handle.clone();
                 std::thread::spawn(move || loop {
                     std::thread::sleep(std::time::Duration::from_secs(4));
+                    // Skip this tick's webview work while a native menu modal
+                    // loop is up (the strip's "⋯" popup). Both `persist` (reads
+                    // each tab's URL) and `recapture_profiles` (reads each tab's
+                    // cookie) marshal into the webviews via the runtime
+                    // dispatcher; on Windows that would re-enter the main thread
+                    // from inside the popup's `TrackPopupMenu` modal loop and
+                    // deadlock the UI (issue #33). The next tick (after the menu
+                    // closes) catches up — both are idempotent and only act on a
+                    // real change.
+                    {
+                        let state = sess_handle.state::<AppState>();
+                        if state.menu_open.load(std::sync::atomic::Ordering::SeqCst) {
+                            continue;
+                        }
+                    }
                     session::persist(&sess_handle);
                     if strip::enabled() {
                         strip::recapture_profiles(&sess_handle);

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -104,6 +104,16 @@ pub struct AppState {
     pub stderr_tail: Mutex<Vec<String>>,
     /// Human-readable reason for the last connection failure.
     pub last_error_hint: Mutex<String>,
+    /// True while a NATIVE menu modal loop is up (the strip's "⋯" popup —
+    /// `Menu::popup`). On Windows that popup runs a nested `TrackPopupMenu`
+    /// message loop ON THE MAIN THREAD; any background work that marshals back
+    /// into a webview (cookie/URL getters via the runtime dispatcher) would
+    /// re-enter the main thread from inside that modal loop, which WebView2
+    /// forbids → the UI thread deadlocks (AppHangB1: frozen menu, window stuck
+    /// topmost, Preferences/Quit dead). The periodic autosave + profile-dot
+    /// sweep checks this and skips its webview marshals while a menu is open,
+    /// catching up on the next tick once it closes (issue #33).
+    pub menu_open: AtomicBool,
 }
 
 impl AppState {
@@ -129,6 +139,7 @@ impl AppState {
             tunnel_status: Mutex::new(TunnelStatus::Disconnected),
             stderr_tail: Mutex::new(Vec::new()),
             last_error_hint: Mutex::new(String::new()),
+            menu_open: AtomicBool::new(false),
         }
     }
 }

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -1000,6 +1000,18 @@ fn capture_tab_profile(app: &AppHandle, window_label: &str, tab_label: &str) {
 /// WebUI signal. `capture_tab_profile` only emits when a value actually
 /// changed, so this is cheap. Runs on a worker thread (cookie reads marshal).
 pub fn recapture_profiles(app: &AppHandle) {
+    // Cookie reads marshal into each webview via the runtime dispatcher. If a
+    // native menu modal loop is up (the strip's "⋯" popup), that marshal would
+    // re-enter the main thread from inside the popup's modal loop on Windows and
+    // deadlock the UI (issue #33). Skip while a menu is open — the periodic
+    // sweep recovers on the next tick once it closes.
+    if app
+        .state::<AppState>()
+        .menu_open
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return;
+    }
     let pairs: Vec<(String, String)> = {
         let state = app.state::<AppState>();
         let strip = state.strip.lock().unwrap();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
Fixes #33.

## The bug
On Windows v0.5.0, clicking the strip's **"⋯" overflow menu** froze the app ~2-3 seconds after it opened: the menu went unresponsive, the window got stuck **always-on-top** (blocking other apps), and **Preferences/Quit stopped working** — only a Task Manager kill recovered it. Windows logged it as `AppHangB1` (main UI thread stopped pumping its message loop).

@b3nw's key diagnostic narrowed it precisely:
> no, its a time thing, 2-3 seconds after the 3 dots is open … doesn't matter what you hover/select

So it isn't the menu handler or any particular item — it's a **timer firing while the menu is open**.

## Root cause
1. `strip_menu` is a synchronous Tauri command → runs on the **main thread** → `menu.popup(win)` enters Windows' native **`TrackPopupMenu` modal message loop**, which owns the main thread until the menu is dismissed.
2. A periodic **4-second timer** (`main.rs`, session autosave + per-tab profile-dot refresh) calls:
   - `session::persist` → `capture` → reads each tab's **URL**, and
   - `strip::recapture_profiles` → `capture_tab_profile` → reads each tab's **cookie** (`wv.cookies()`).
   
   Both **marshal back onto the main thread** via the runtime dispatcher (the code already documents this: *"cookie reads marshal … must not be called from inside a wry callout"*, strip.rs).
3. When that marshal lands while the popup's modal loop already holds the main thread, it **re-enters the main thread from inside the modal loop** — exactly what WebView2 forbids — and the UI thread deadlocks. ~2-3s after opening = the 4s tick landing mid-menu, independent of hover/select. This is the same reentrancy hazard family the codebase already fights for AppKit (see `macos.rs` notes) and for synchronous webview creation in IPC commands (`windows.rs:971-973`).

## The fix
A `menu_open` flag on `AppState`, set for the duration of the popup. The 4s timer **skips its webview reads while a menu is open** and catches up on the next tick once it closes. `recapture_profiles` also self-guards at the function level for any future caller. Both paths are idempotent and only act on a real change, so a skipped tick is harmless — the dot/session state is captured on the very next 4s tick.

Three layers:
- `strip_menu` sets/clears `menu_open` around `menu.popup` (`main.rs`).
- The 4s timer early-`continue`s while `menu_open` is set (`main.rs`).
- `recapture_profiles` early-returns while `menu_open` is set (`strip.rs`).

## Scope
Desktop-wrapper only. Windows-specific symptom, but the guard is safe cross-platform (on macOS/Linux `popup` returns immediately so the flag is naturally short-lived). WebUI side needs nothing.

## Testing
- `cargo fmt --check` passes.
- `AppState` is only ever built via `AppState::new()` (updated); no struct-literal construction elsewhere, existing unit tests don't touch it.
- Full `cargo clippy -D warnings` / `cargo test` / platform builds run in CI (macos-14 runner) — local `cargo check` can't run here (no GTK system libs in this sandbox), so CI is the authoritative compile gate.
- **Manual Windows verification still wanted** (I can't repro the native modal loop on this box): open the "⋯" menu, leave it open >5s, dismiss — confirm the window stays interactable, is **not** stuck topmost, and Preferences/Quit still fire; then confirm the profile dot still refreshes within ~4s after an in-tab profile switch.

Bumps to **v0.6.0** + CHANGELOG.
