### PR TITLE
fix: fully resolve ⋯-menu hang #33 (guard cookies() at chokepoint) + restored-tab 404 #37 — v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.6.1] — 2026-06-19
+
+### Fixed
+
+- **The "⋯" overflow menu no longer hangs the app on Windows** (issue #33,
+  follow-up to v0.6.0). v0.6.0 moved the popup onto the event loop, but the hang
+  persisted: testers still saw the app freeze ~2-3 seconds after opening the
+  menu — the window stuck on top of everything, Preferences/Quit dead, only a
+  Task Manager kill recovered it. The popup runs a native modal loop that owns
+  the main thread until dismissed; meanwhile a periodic 4-second timer (session
+  autosave + the per-tab profile-dot refresh) reads each tab's cookie/URL, and
+  those reads marshal back onto the main thread. With the menu's modal loop
+  already holding the main thread, that re-entry deadlocked the UI — independent
+  of which item you hovered or selected, exactly matching the "it's a time thing"
+  report. The timer now skips its webview reads while a menu is open and catches
+  up on the next tick once it closes, so the menu stays responsive.
+
 ## [v0.6.0] — 2026-06-18
 
 A bug-squash release: a Windows hang blocker, plus restore/notification/profile-dot fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [v0.6.1] — 2026-06-19
 
+A crash-and-bug-fix release.
+
 ### Fixed
 
 - **The "⋯" overflow menu no longer hangs the app on Windows** (issue #33,
@@ -9,13 +11,22 @@
   persisted: testers still saw the app freeze ~2-3 seconds after opening the
   menu — the window stuck on top of everything, Preferences/Quit dead, only a
   Task Manager kill recovered it. The popup runs a native modal loop that owns
-  the main thread until dismissed; meanwhile a periodic 4-second timer (session
-  autosave + the per-tab profile-dot refresh) reads each tab's cookie/URL, and
-  those reads marshal back onto the main thread. With the menu's modal loop
-  already holding the main thread, that re-entry deadlocked the UI — independent
-  of which item you hovered or selected, exactly matching the "it's a time thing"
-  report. The timer now skips its webview reads while a menu is open and catches
-  up on the next tick once it closes, so the menu stays responsive.
+  the main thread until dismissed; meanwhile background work that reads a tab's
+  cookie or URL marshals back onto the main thread, and that re-entry while the
+  modal loop is up deadlocked the UI — independent of which item you hovered or
+  selected, matching the "it's a time thing" report. Every such read — the
+  periodic 4-second autosave + profile-dot refresh, **and** the
+  navigation-driven profile re-read and page-load capture — now pauses while a
+  menu is open and resumes the moment it closes, so the menu stays responsive.
+- **A restored tab no longer shows "Session not available in web UI." on
+  launch** (issue #37, new in v0.6.0's deep-session restore). Behind a reverse
+  proxy the restored session's first load could 404 before the server was ready
+  to resolve it, leaving the tab on the empty-state until you switched away and
+  back. A restored tab that gets bounced to the home screen now retries its
+  saved session once, a couple seconds later — mirroring that switch-away-and-back
+  recovery — so the session you left off in comes back on its own. (If a tab
+  still lands on the empty-state behind a slow proxy, a manual reload or session
+  switch recovers it.)
 
 ## [v0.6.0] — 2026-06-18
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -173,8 +173,17 @@ fn strip_menu(app: tauri::AppHandle, window: String) {
         if let Ok(menu) = menu::build_strip_menu(&app) {
             let state = app.state::<AppState>();
             state.menu_open.store(true, Ordering::SeqCst);
+            // Reset on scope exit, even if `popup` were to panic — a stuck
+            // `menu_open` would silently freeze session autosave + the profile
+            // dot until restart. (`popup` returns a Result we already ignore.)
+            struct Reset<'a>(&'a std::sync::atomic::AtomicBool);
+            impl Drop for Reset<'_> {
+                fn drop(&mut self) {
+                    self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+            let _reset = Reset(&state.menu_open);
             let _ = menu.popup(win);
-            state.menu_open.store(false, Ordering::SeqCst);
         }
     });
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -155,13 +155,26 @@ fn strip_menu(app: tauri::AppHandle, window: String) {
     // HERMES_FORCE_STRIP). A context-menu popup doesn't force a window redraw
     // the way addTabbedWindow does, so there's no draw_rect re-entrancy here. If
     // the strip ever ships on macOS, route this popup through dispatch_main_async.
+    //
+    // Marshaling the popup onto the event loop (above) was NOT enough to fix #33
+    // on its own: `popup` still runs a nested `TrackPopupMenu` modal loop that
+    // owns the main thread until dismissed, and the periodic 4s autosave +
+    // profile-dot timer reads each tab's cookie/URL (which marshal back onto the
+    // main thread) — that re-entry during the modal loop is the actual deadlock
+    // (b3nw on v0.6.0: "2-3 seconds after the 3 dots is open, doesn't matter
+    // what you hover/select"). Flag `menu_open` for the duration so the timer
+    // skips its webview reads while the menu is up and catches up once it closes.
     let _ = app.clone().run_on_main_thread(move || {
+        use std::sync::atomic::Ordering;
         use tauri::menu::ContextMenu;
         let Some(win) = app.windows().get(&window).cloned() else {
             return;
         };
         if let Ok(menu) = menu::build_strip_menu(&app) {
+            let state = app.state::<AppState>();
+            state.menu_open.store(true, Ordering::SeqCst);
             let _ = menu.popup(win);
+            state.menu_open.store(false, Ordering::SeqCst);
         }
     });
 }
@@ -323,6 +336,21 @@ fn main() {
                 let sess_handle = handle.clone();
                 std::thread::spawn(move || loop {
                     std::thread::sleep(std::time::Duration::from_secs(4));
+                    // Skip this tick's webview work while a native menu modal
+                    // loop is up (the strip's "⋯" popup). Both `persist` (reads
+                    // each tab's URL) and `recapture_profiles` (reads each tab's
+                    // cookie) marshal into the webviews via the runtime
+                    // dispatcher; on Windows that would re-enter the main thread
+                    // from inside the popup's `TrackPopupMenu` modal loop and
+                    // deadlock the UI (#33). The next tick (once the menu closes)
+                    // catches up — both are idempotent and only act on a change.
+                    if sess_handle
+                        .state::<AppState>()
+                        .menu_open
+                        .load(std::sync::atomic::Ordering::SeqCst)
+                    {
+                        continue;
+                    }
                     session::persist(&sess_handle);
                     if strip::enabled() {
                         strip::recapture_profiles(&sess_handle);

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -97,6 +97,17 @@ pub fn load(app: &AppHandle) -> Option<Session> {
 /// everywhere must touch the runtime on its own thread) and blocks the caller
 /// for the result — so call it only from a worker thread, never the main one.
 fn capture(app: &AppHandle) -> Session {
+    // Chokepoint guard (#33): capture reads each tab's URL (`webview.url()`), a
+    // synchronous WebView2 read that pumps a nested loop on the main thread.
+    // While the strip's "⋯" popup owns the main thread (TrackPopupMenu modal
+    // loop), that re-entry deadlocks the UI. The 4s timer already skips while
+    // `menu_open`, but guard here too so no `persist` path (or the tiny window
+    // where the timer passed its check just before the menu opened) can slip a
+    // URL read in mid-popup. Returns empty → persist's empty-guard drops it; the
+    // next tick captures once the menu closes.
+    if app.state::<AppState>().menu_open.load(Ordering::SeqCst) {
+        return Session::default();
+    }
     let (tx, rx) = mpsc::channel();
     let app2 = app.clone();
     if app

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -110,6 +110,18 @@ pub struct AppState {
     pub stderr_tail: Mutex<Vec<String>>,
     /// Human-readable reason for the last connection failure.
     pub last_error_hint: Mutex<String>,
+    /// True while a NATIVE menu modal loop is up (the strip's "⋯" popup —
+    /// `Menu::popup`). On Windows that popup runs a nested `TrackPopupMenu`
+    /// message loop ON THE MAIN THREAD; any background work that marshals back
+    /// into a webview (cookie/URL getters via the runtime dispatcher) would
+    /// re-enter the main thread from inside that modal loop, which WebView2
+    /// forbids → the UI thread deadlocks (#33: AppHangB1 ~2-3s after opening the
+    /// menu, window stuck topmost, Preferences/Quit dead). Moving `popup` onto
+    /// the event loop (v0.6.0 / #34) did NOT fix this — the modal loop still owns
+    /// the main thread while it's up. The periodic autosave + profile-dot sweep
+    /// checks this flag and skips its webview marshals while a menu is open,
+    /// catching up on the next tick once it closes.
+    pub menu_open: AtomicBool,
 }
 
 impl AppState {
@@ -136,6 +148,7 @@ impl AppState {
             tunnel_status: Mutex::new(TunnelStatus::Disconnected),
             stderr_tail: Mutex::new(Vec::new()),
             last_error_hint: Mutex::new(String::new()),
+            menu_open: AtomicBool::new(false),
         }
     }
 }

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -1005,6 +1005,18 @@ fn capture_tab_profile(app: &AppHandle, window_label: &str, tab_label: &str) {
 /// WebUI signal. `capture_tab_profile` only emits when a value actually
 /// changed, so this is cheap. Runs on a worker thread (cookie reads marshal).
 pub fn recapture_profiles(app: &AppHandle) {
+    // Cookie reads marshal into each webview via the runtime dispatcher. If a
+    // native menu modal loop is up (the strip's "⋯" popup), that marshal would
+    // re-enter the main thread from inside the popup's modal loop on Windows and
+    // deadlock the UI (#33). Skip while a menu is open — the periodic sweep
+    // recovers on the next tick once it closes.
+    if app
+        .state::<AppState>()
+        .menu_open
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return;
+    }
     let pairs: Vec<(String, String)> = {
         let state = app.state::<AppState>();
         let strip = state.strip.lock().unwrap();

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -302,6 +302,9 @@ pub fn restore_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
             } else {
                 Vec::new()
             };
+        // Arm the boot-404 retry (#37) only for a deep (non-root) session URL;
+        // a root restore has nothing to recover.
+        let restore_retry = (!matches!(url.path(), "" | "/")).then(|| url.clone());
         add_tab_with(
             app,
             &label,
@@ -311,6 +314,7 @@ pub fn restore_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
                 partition_override: tab.partition.clone(),
                 profile_hint: tab.profile.clone(),
                 custom_title: tab.custom_title.clone(),
+                restore_retry,
             },
         );
     }
@@ -430,6 +434,7 @@ pub fn add_tab(app: &AppHandle, window_label: &str) {
             partition_override: None,
             profile_hint: None,
             custom_title: None,
+            restore_retry: None,
         },
     );
 }
@@ -447,6 +452,12 @@ pub(crate) struct TabSpec {
     pub profile_hint: Option<String>,
     /// Restored user-given tab name (issue #7).
     pub custom_title: Option<String>,
+    /// Set (to the saved deep-link URL) for a RESTORED tab on a non-root
+    /// session. If the boot load bounces to root — the WebUI's self-heal when
+    /// `GET /api/session` 404s transiently behind a proxy (issue #37) — the tab
+    /// re-navigates here once, mirroring the user's switch-away-and-back
+    /// recovery. None for normal new tabs and root restores.
+    pub restore_retry: Option<url::Url>,
 }
 
 /// Shared tab-creation body: build an isolated content webview, append it to
@@ -459,6 +470,7 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
         partition_override,
         profile_hint,
         custom_title,
+        restore_retry,
     } = spec;
     let Some(win) = app.windows().get(window_label).cloned() else {
         return;
@@ -623,6 +635,38 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
     emit_tabs(app, window_label);
     refresh_window_title(app, window_label);
     crate::session::persist(app);
+
+    // Boot-time session-restore retry (issue #37): a restored deep-link tab can
+    // 404 on its first `GET /api/session` behind a proxy (server/session index
+    // not ready yet), and the WebUI self-heals by bouncing the URL to root and
+    // showing "Session not available". The session IS reachable a beat later
+    // (the user's switch-away-and-back recovery proves it). So once, ~2.5s after
+    // create, if the tab has bounced to root, re-navigate to the saved deep URL.
+    // No-op if it loaded fine (route still deep) → no penalty on success.
+    if let Some(deep) = restore_retry {
+        let app2 = app.clone();
+        let wv2 = webview.clone();
+        let tab2 = tab_label.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(2500));
+            let bounced = crate::session::reported_url(&app2, &tab2)
+                .as_deref()
+                .map(url_is_root)
+                .unwrap_or(false);
+            if bounced {
+                log::info!("strip: restored tab {tab2} bounced to root — retrying {deep}");
+                let _ = wv2.navigate(deep);
+            }
+        });
+    }
+}
+
+/// Whether a reported URL is the WebUI root (path `/` or empty) — the shape the
+/// WebUI bounces a tab to when a boot-time deep-link session load 404s (#37).
+fn url_is_root(u: &str) -> bool {
+    url::Url::parse(u)
+        .map(|p| matches!(p.path(), "" | "/"))
+        .unwrap_or(false)
 }
 
 pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
@@ -964,6 +1008,22 @@ pub fn profile_from_cookies(cookies: &[Cookie<'static>]) -> Option<String> {
 /// session (#18). Runs on a worker thread — the cookie read marshals via the
 /// dispatcher, so it must not be called from inside a wry callout (wry#583).
 fn capture_tab_profile(app: &AppHandle, window_label: &str, tab_label: &str) {
+    // Guard the cookie read at the CHOKEPOINT, not just at the periodic sweep
+    // (#33). `wv.cookies()` is a synchronous WebView2 read that marshals onto —
+    // and pumps a nested loop on — the main thread. While the strip's "⋯" popup
+    // owns the main thread (TrackPopupMenu modal loop), that re-entry deadlocks
+    // the UI. recapture_profiles guards itself, but capture_tab_profile is ALSO
+    // reached from the `route` bridge handler (recapture_tab_profile, fired by a
+    // background SSE-driven navigation) and on_page_load — both unguarded
+    // otherwise. Guarding here covers every caller; the value is re-read on the
+    // next route/sweep once the menu closes.
+    if app
+        .state::<AppState>()
+        .menu_open
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return;
+    }
     let Some(win) = app.windows().get(window_label).cloned() else {
         return;
     };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
Fixes #33 (the part v0.6.0 / #34 didn't resolve).

## Status: the hang is NOT fixed on v0.6.0
@b3nw tested v0.6.0 after updating and the freeze persists:
> freeze is not fixed … it seems to trigger as you go over the version ID … **no, it's a time thing, 2-3 seconds after the 3 dots is open** … doesn't matter what you hover/select

This is exactly the failure mode predicted on #33: #34 marshaled the popup onto the event loop, but that only changed *where the popup is invoked from* — the native modal loop still owns the main thread while the menu is up, so the real trigger was never addressed.

## Root cause (the other half of the deadlock)
1. `Menu::popup` runs a nested Windows **`TrackPopupMenu` modal message loop** that owns the **main thread** until the menu is dismissed.
2. A periodic **4-second timer** (`main.rs`) calls:
   - `session::persist` → `capture` → reads each tab's **URL**, and
   - `strip::recapture_profiles` → `capture_tab_profile` → reads each tab's **cookie** (`wv.cookies()`).
   
   Both **marshal back onto the main thread** via the runtime dispatcher (the code already documents this: *"cookie reads marshal … must not be called from inside a wry callout"*).
3. When that marshal lands while the popup's modal loop already holds the main thread, it **re-enters WebView2 from inside the modal loop** — which WebView2 forbids — and the UI thread deadlocks (`AppHangB1`). ~2-3s after opening = the next 4s tick landing mid-menu, independent of hover/select. That's why "it's a time thing."

## The fix
A `menu_open` flag on `AppState`, set for the duration of the popup. The 4s timer **skips its webview reads while a menu is open** and catches up on the next tick once it closes. `recapture_profiles` also self-guards at the function level. Both paths are idempotent and only act on a real change, so a skipped tick is harmless — the dot/session state is captured on the very next tick.

Three layers:
- `strip_menu` sets/clears `menu_open` around `menu.popup` (`main.rs`, inside #34's event-loop closure).
- The 4s timer early-`continue`s while `menu_open` is set (`main.rs`).
- `recapture_profiles` early-returns while `menu_open` is set (`strip.rs`).

This is additive on top of #34 — keeps the popup on the event loop *and* closes the timer-marshal race.

## Scope
Desktop-wrapper only. Windows-specific symptom; guard is safe cross-platform (on macOS/Linux `popup` returns immediately so the flag is naturally short-lived). WebUI side needs nothing.

## Testing
- `cargo fmt --check` passes.
- `AppState` is only built via `AppState::new()` (updated); no struct-literal construction elsewhere; existing unit tests don't touch it.
- Full `cargo clippy -D warnings` / `cargo test` / platform builds run in CI (macos-14) — local `cargo check` can't run in this sandbox (no GTK system libs), so CI is the authoritative compile gate.
- **Windows verification wanted:** open the "⋯" menu, leave it open >5s, dismiss — confirm the window stays interactable, is **not** stuck topmost, and Preferences/Quit still fire; then confirm the profile dot still refreshes within ~4s after an in-tab profile switch. (@b3nw offered a Windows VM to remote into — that would let us confirm directly before release.)

Bumps to **v0.6.1** + CHANGELOG.
