### PR TITLE
v0.6.2 — bug squash: fix Windows session-restore (real root cause), profile dot, tab rename, hide-bar hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## [v0.6.2] — 2026-06-19
+
+A bug-squash release centered on the Windows session-restore failures that
+earlier releases only appeared to fix — they were validated on the macOS
+forced-strip harness, which doesn't reproduce WebView2's cookie behavior, so
+they shipped still broken on Windows. This release traces and fixes the actual
+root cause.
+
+### Fixed
+
+- **Windows: a restored tab now reopens on the right profile and its real
+  session, instead of bouncing to the home screen with "Session not available in
+  web UI."** (issues #30 and #37 — one root cause; #30 was marked fixed in v0.6.0
+  and #37 in v0.6.1, but both kept happening on Windows). The profile selector
+  (`hermes_profile`) is a *session* cookie, and WebView2 discards session cookies
+  from a tab's on-disk data folder when the app restarts. So a restored tab —
+  even though it reuses its data folder to keep you logged in — came back on the
+  *default* profile, and its saved `/session/<id>` link is profile-scoped, so the
+  server returned it as not-found and the tab bounced to the home screen. The app
+  now re-establishes the saved profile on restore by re-seeding that one cookie
+  before the tab loads, pinned to the server's host so WebView2 actually sends it
+  — a cookie set without an explicit host is silently dropped there, which is why
+  the earlier attempt looked right in testing yet did nothing on Windows. Your
+  login and drafts still ride along in the reused data folder; only the profile
+  selector is restored. (macOS was unaffected — its webview keeps the in-memory
+  cookie for the life of the app.)
+- **Windows/Linux: the per-tab profile dot is now correct on launch and never
+  shows for the default profile** (issue #31, follow-on to v0.6.0). The dot was
+  driven by the profile *cookie*, which the WebUI sets only on an explicit
+  switch — so a tab that simply *started* on a named profile showed no dot, while
+  a tab switched back to the default profile (or a renamed root profile) showed a
+  spurious one. Each tab's page now reports its actual active profile and that
+  drives the dot directly: it appears on the starting profile, and the default
+  profile correctly shows nothing.
+- **Windows/Linux: renaming a tab no longer has the edit box vanish as you type**
+  (issue #38). Double-clicking a tab opens an inline rename field, but the active
+  tab's title changes constantly while a chat streams, and each change rebuilt the
+  tab strip — destroying the open field mid-keystroke. The strip now rebuilds only
+  when something it actually shows has changed, and never while a rename is in
+  progress, so the field stays put until you press Enter or Escape.
+- **Windows: hiding the tab bar now tells you how to bring it back** (issue #10).
+  Hiding the bar (the "⋯" menu or Ctrl+Shift+B) also hides the "⋯" button — the
+  only on-screen control — leaving first-time users with no way to discover how to
+  restore it. Hiding it now shows an OS notification with the shortcut, and keeps
+  reminding you on each hide until you've successfully brought the bar back at
+  least once (so the hint isn't wasted if the notification was suppressed).
+
 ## [v0.6.1] — 2026-06-19
 
 A crash-and-bug-fix release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.6.0",
+  "version": "0.6.2",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.6.1"
+version = "0.6.2"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -492,6 +492,35 @@ const ROUTE_REPORTER: &str = r##"
   })();
 "##;
 
+/// S15 — active-profile reporter (issue #31): report the tab's active profile
+/// NAME so the strip can show the profile dot on the STARTING profile, not just
+/// after a switch. The WebUI sets the `hermes_profile` cookie only on an
+/// explicit `/api/profile/switch` — never on boot — so the shell's cookie-based
+/// dot is blank for a tab sitting on its launch profile. The page always knows
+/// the name (`/api/profile/active` → `{name, is_default}`), so it reports it
+/// (empty for the default profile = no dot), debounced to fire only on change.
+const PROFILE_REPORTER: &str = r##"
+  (function () {
+    var last = null;
+    var report = function () {
+      try {
+        fetch('/api/profile/active', { credentials: 'same-origin' })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (p) {
+            if (!p) return;
+            var name = p.is_default ? '' : (p.name || '');
+            if (name !== last) { last = name; EMIT('profile', name); }
+          })
+          .catch(function () {});
+      } catch (e) {}
+    };
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', report);
+    else report();
+    setInterval(report, 3000);
+    window.addEventListener('focus', report);
+  })();
+"##;
+
 /// Assemble the per-window initialization script.
 pub fn init_script(label: &str, pre_paint_hex: &str, is_ssh: bool) -> String {
     let mut parts: Vec<&str> = vec![HELPER, PRE_PAINT, NOTIFICATION_SHIM, SPEECH_SUPPRESS];
@@ -503,6 +532,9 @@ pub fn init_script(label: &str, pre_paint_hex: &str, is_ssh: bool) -> String {
     }
     if cfg!(not(target_os = "macos")) {
         parts.push(SHORTCUT_FORWARDER);
+        // Profile dot is strip-only (Windows/Linux); macOS native tabs have no
+        // dot, so skip the reporter's polling there (issue #31).
+        parts.push(PROFILE_REPORTER);
     }
     parts.push(THEME_BRIDGE);
     parts.push(ROUTE_REPORTER);
@@ -563,6 +595,14 @@ pub fn install(app: &AppHandle) {
                     let app = handle.clone();
                     let tab = label.clone();
                     std::thread::spawn(move || crate::strip::recapture_tab_profile(&app, &tab));
+                }
+            }
+            // Active-profile NAME (issue #31) — drives the strip dot even on the
+            // starting profile (where no hermes_profile cookie exists yet).
+            "profile" => {
+                if crate::strip::enabled() && label.starts_with("tab-") {
+                    let name = payload["value"].as_str().unwrap_or("").to_string();
+                    crate::strip::set_tab_dot_profile(&handle, &label, &name);
                 }
             }
             "notify" => {

--- a/src-tauri/src/prefs.rs
+++ b/src-tauri/src/prefs.rs
@@ -239,3 +239,19 @@ pub fn fullscreen_set(app: &AppHandle, v: bool) {
         let _ = store.save();
     }
 }
+
+// ---- One-time "tab bar hidden" hint (issue #10 discoverability) ----
+
+/// Whether the one-time "Tab bar hidden — Ctrl+Shift+B to show it" hint has
+/// already been shown. Hiding the strip removes the ⋯ button (the only visible
+/// affordance), so a first-time hider needs to learn the un-hide shortcut.
+pub fn hide_hint_shown(app: &AppHandle) -> bool {
+    get_bool(app, "tabBarHideHintShown", false)
+}
+
+pub fn set_hide_hint_shown(app: &AppHandle) {
+    if let Ok(store) = app.store(STORE_FILE) {
+        store.set("tabBarHideHintShown", json!(true));
+        let _ = store.save();
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -28,6 +28,15 @@ pub struct TabEntry {
     /// per-tab profile dot (issue #8) and is persisted so a restored tab
     /// reopens on the same profile (issue #18).
     pub profile: Option<String>,
+    /// The active profile NAME reported by the page (`/api/profile/active`),
+    /// used to render the dot (issue #31). The WebUI sets the `hermes_profile`
+    /// cookie only on an explicit switch (never on boot), so `profile` above is
+    /// empty for a tab sitting on its starting profile → no dot. The page knows
+    /// the name regardless, so it reports it; the frontend prefers this for the
+    /// dot. Display-only (the canonical name, consistent across auth/no-auth) —
+    /// `profile` (the cookie value) remains the source for restore re-seeding.
+    /// Transient: re-derived by the reporter on every launch, not persisted.
+    pub dot_profile: Option<String>,
     /// The on-disk data-partition directory name backing this tab's cookie jar
     /// (Windows/Linux). Normally the tab label, but a tab restored from a saved
     /// session reuses its *previous* partition so login + cookies survive the

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -88,15 +88,44 @@ pub fn toggle_strip(app: &AppHandle, window_label: &str) {
         log::info!("strip: tab-bar toggle unavailable on Linux (GTK child-webview geometry)");
         return;
     }
-    {
+    let now_hidden = {
         let state = app.state::<AppState>();
         let mut strip = state.strip.lock().unwrap();
         let Some(entry) = strip.get_mut(window_label) else {
             return;
         };
         entry.strip_hidden = !entry.strip_hidden;
-    }
+        entry.strip_hidden
+    };
     layout(app, window_label);
+    // Discoverability (issue #10): hiding the strip removes the ⋯ button — the
+    // only visible affordance — so until the user has proven they know how to
+    // bring it back, surface an OS notification with the shortcut every time
+    // they hide it.
+    //
+    // We retire the hint on the UN-HIDE transition, NOT on hide. Un-hiding (on
+    // Windows, the only platform this runs on for real) REQUIRES Ctrl+Shift+B
+    // since the ⋯ button is gone — so a successful un-hide is positive proof
+    // the user learned the shortcut, and only then do we stop hinting. Gating
+    // on the hide instead (the previous logic) burned the one-time flag even
+    // when the toast was silently dropped — Focus Assist / Do-Not-Disturb,
+    // notifications disabled for the app, or an unpackaged dev build — leaving
+    // a first-time hider permanently stuck with the hint already "spent". This
+    // way the hint simply re-fires on the next hide until it actually lands.
+    if now_hidden {
+        if !prefs::hide_hint_shown(app) {
+            use tauri_plugin_notification::NotificationExt;
+            let _ = app
+                .notification()
+                .builder()
+                .title("Tab bar hidden")
+                .body("Press Ctrl+Shift+B to show it again.")
+                .show();
+        }
+    } else if !prefs::hide_hint_shown(app) {
+        // Just un-hid → they know the shortcut now. Stop hinting.
+        prefs::set_hide_hint_shown(app);
+    }
 }
 
 /// Per-tab webview data partition path. Each tab gets its own directory → its
@@ -290,18 +319,41 @@ pub fn restore_window(app: &AppHandle, sw: &crate::session::SessionWindow) {
                 Err(_) => continue,
             },
         };
-        // With a saved partition, REUSE the on-disk jar (login + cookies persist,
-        // issue #28) — no seed needed. Without one (pre-0.5.0 blob / macOS),
-        // fall back to a fresh jar re-seeded with the profile selector (#18).
-        let seed: Vec<Cookie<'static>> =
-            if tab.partition.is_none() && cfg!(not(target_os = "macos")) {
-                tab.profile
-                    .as_deref()
-                    .map(|v| vec![crate::session::profile_cookie(v)])
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
+        // ALWAYS re-seed the profile cookie for a restored tab (issue #30/#37),
+        // even when reusing the partition. `hermes_profile` is a SESSION cookie
+        // (no expiry), and WebView2 discards session cookies from the
+        // data_directory on process restart — so reusing the jar does NOT bring
+        // the profile back on Windows: the tab boots on the default profile, and
+        // its saved `/session/<id>` deep-link is then profile-gated to a 404
+        // ("Session not available", #37), bouncing to root (#30). Re-seeding the
+        // captured profile selector re-establishes it deterministically instead
+        // of relying on cookie persistence. The partition is still REUSED
+        // (login/localStorage survive); we only add back the one selector
+        // cookie. (macOS strip = HERMES_FORCE_STRIP dev only, no data_directory,
+        // so seeding is a no-op there.)
+        let seed: Vec<Cookie<'static>> = if cfg!(not(target_os = "macos")) {
+            tab.profile
+                .as_deref()
+                .map(|v| {
+                    let mut c = crate::session::profile_cookie(v);
+                    // CRITICAL (#30/#37): pin the cookie to the navigation host.
+                    // wry's `set_cookie` carries no URL, so on WebView2 a
+                    // domain-less cookie becomes `CreateCookie(.., domain="")`
+                    // — which has no host to match and is SILENTLY never sent,
+                    // leaving the restored tab on the default profile (the bug).
+                    // Setting the domain to the target host (host-only-
+                    // equivalent for localhost) is what actually makes the
+                    // re-seed take effect on Windows. macOS native restore keeps
+                    // the domain-less form WKWebView accepts (windows.rs).
+                    if let Some(h) = url.host_str() {
+                        c.set_domain(h.to_string());
+                    }
+                    vec![c]
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
         // Arm the boot-404 retry (#37) only for a deep (non-root) session URL;
         // a root restore has nothing to recover.
         let restore_retry = (!matches!(url.path(), "" | "/")).then(|| url.clone());
@@ -520,8 +572,13 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
     // (issue #8).
     let seed_profile = profile_hint.or_else(|| profile_from_cookies(&seed));
 
-    // Seed only a FRESH isolated jar; a reused jar already carries its cookies.
-    let do_seed = partition.is_some() && !reuse && !seed.is_empty();
+    // Seed whenever we have cookies to inject into an isolated jar — INCLUDING a
+    // reused jar (issue #30/#37): the reused jar may have lost the session-scoped
+    // `hermes_profile` cookie across restart (WebView2 drops session cookies), so
+    // a restored tab must re-seed its profile selector before navigating, or its
+    // deep-link load 404s under the wrong profile. set_cookie only adds/updates
+    // that one cookie; the rest of the reused jar (login/localStorage) is intact.
+    let do_seed = partition.is_some() && !seed.is_empty();
     // about:blank first ONLY when seeding (so the cookie lands before the real
     // navigation); reused / un-isolated tabs load the target directly.
     let initial_url = if do_seed {
@@ -624,7 +681,19 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
             label: tab_label.clone(),
             title,
             attention: false,
-            profile: seed_profile,
+            profile: seed_profile.clone(),
+            // Seed the dot from the profile we know at creation so a non-default
+            // tab shows it instantly (and degrades gracefully on a server too
+            // old to expose /api/profile/active); the page's active-profile
+            // reporter refines it after load (issue #31). Filter the literal
+            // "default": the WebUI persists `hermes_profile=default` on an
+            // explicit switch-to-default, but the default profile must show NO
+            // dot — the reporter (is_default) would blank it anyway, this just
+            // avoids the flash. `profile` keeps the raw value for re-seeding.
+            dot_profile: seed_profile
+                .as_deref()
+                .filter(|v| *v != "default")
+                .map(str::to_string),
             partition: partition_id,
             custom_title,
         });
@@ -939,24 +1008,68 @@ pub fn set_tab_title(app: &AppHandle, tab_label: &str, title: &str, attention: b
         .lock()
         .unwrap()
         .insert(tab_label.to_string(), title.to_string());
-    {
+    let changed = {
         let mut strip = state.strip.lock().unwrap();
-        if let Some(entry) = strip.get_mut(&window_label) {
-            if let Some(tab) = entry.tabs.iter_mut().find(|t| t.label == tab_label) {
+        match strip
+            .get_mut(&window_label)
+            .and_then(|e| e.tabs.iter_mut().find(|t| t.label == tab_label))
+        {
+            Some(tab) => {
                 let p = prefs::load(app);
                 // A user-renamed tab (#7) keeps its name regardless of the page
                 // title; the page title is still recorded (raw_titles above) so
                 // clearing the rename can fall back to it.
-                if tab.custom_title.is_none() {
-                    tab.title =
-                        windows::display_title(title, &p.connection_mode, &p.target_url, true);
-                }
+                let new_title = if tab.custom_title.is_none() {
+                    windows::display_title(title, &p.connection_mode, &p.target_url, true)
+                } else {
+                    tab.title.clone()
+                };
+                let changed = tab.title != new_title || tab.attention != attention;
+                tab.title = new_title;
                 tab.attention = attention;
+                changed
             }
+            None => false,
         }
+    };
+    // Emit only when something the strip renders actually changed — the WebUI
+    // mutates document.title constantly (token streaming), and emitting on every
+    // one floods the strip with rebuilds (it destroyed the open rename input,
+    // #38, and is needless churn). refresh_window_title is cheap/idempotent.
+    if changed {
+        emit_tabs(app, &window_label);
+        refresh_window_title(app, &window_label);
     }
-    emit_tabs(app, &window_label);
-    refresh_window_title(app, &window_label);
+}
+
+/// Set a tab's display profile name for the dot (issue #31), reported by the
+/// page's active-profile reporter. Independent of the `hermes_profile` cookie
+/// (which the WebUI doesn't set until an explicit switch), so a tab on its
+/// starting profile still gets a dot. Empty name = default profile = no dot.
+/// Emits only on change. No webview read here (just a string from the bridge),
+/// so it's safe regardless of the menu modal loop (#33).
+pub fn set_tab_dot_profile(app: &AppHandle, tab_label: &str, name: &str) {
+    let Some(window_label) = window_of_tab(tab_label) else {
+        return;
+    };
+    let value = (!name.is_empty()).then(|| name.to_string());
+    let state = app.state::<AppState>();
+    let changed = {
+        let mut strip = state.strip.lock().unwrap();
+        match strip
+            .get_mut(&window_label)
+            .and_then(|e| e.tabs.iter_mut().find(|t| t.label == tab_label))
+        {
+            Some(tab) if tab.dot_profile != value => {
+                tab.dot_profile = value;
+                true
+            }
+            _ => false,
+        }
+    };
+    if changed {
+        emit_tabs(app, &window_label);
+    }
 }
 
 /// Rename a strip tab (issue #7). `name` = the user's label, or None/empty to

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"

--- a/src/shell.html
+++ b/src/shell.html
@@ -188,6 +188,9 @@
       let healthy = true;
       let dragFrom = -1; // index of the tab being dragged (#19)
       let dragLabel = ""; // label of the tab being dragged
+      let renaming = false; // a rename input is open (#38) — suppress rebuilds
+      let renamingLabel = null; // the tab label being renamed (#38)
+      let lastSnapshot = null; // most recent tabs snapshot, to re-apply after edit
 
       // Stable-ish color for a profile name → its dot (issue #8). The default
       // profile (no cookie) gets no dot.
@@ -206,6 +209,8 @@
       // Inline tab rename (issue #7): swap the title span for an input.
       function startRename(el, titleSpan, tabLabel, current) {
         if (el.querySelector("input.rename")) return;
+        renaming = true; // suppress strip rebuilds until the edit ends (#38)
+        renamingLabel = tabLabel;
         const input = document.createElement("input");
         input.className = "rename";
         input.value = current;
@@ -216,6 +221,8 @@
         const finish = (save) => {
           if (done) return;
           done = true;
+          renaming = false;
+          renamingLabel = null;
           if (save) {
             // Empty/whitespace clears the custom name (backend reverts to title).
             hermes.invoke("tab_rename", {
@@ -223,10 +230,12 @@
               tab: tabLabel,
               name: input.value,
             });
-            // backend emits tabs-changed → renderTabs rebuilds the strip.
-          } else {
-            hermes.invoke("tabs_snapshot", { window: WIN }).then(renderTabs);
+            // backend emits tabs-changed → renderTabs rebuilds with the new name.
           }
+          // Re-apply the latest snapshot now so the input is replaced at once
+          // (and any snapshot that arrived while editing is reflected). On save,
+          // the backend's tabs-changed then repaints the new name.
+          if (lastSnapshot) renderTabs(lastSnapshot);
         };
         input.addEventListener("keydown", (e) => {
           e.stopPropagation();
@@ -245,6 +254,21 @@
 
       function renderTabs(snapshot) {
         if (snapshot.window !== WIN) return;
+        lastSnapshot = snapshot;
+        // Don't rebuild the strip while a rename input is open (issue #38): the
+        // active tab's document-title churn fires `tabs-changed` every couple
+        // seconds, and a rebuild (`root.textContent = ""`) would destroy the
+        // freshly-opened <input> — "appears then vanishes instantly" on Windows.
+        // The edit re-applies the latest snapshot when it finishes.
+        //
+        // Exception: if the tab being renamed is no longer in the snapshot (it
+        // was closed mid-edit), release the rename and fall through to rebuild
+        // — otherwise the orphaned <input> would linger on a now-gone tab.
+        if (renaming && document.querySelector("#tabs input.rename")) {
+          if (snapshot.tabs.some((t) => t.label === renamingLabel)) return;
+          renaming = false;
+          renamingLabel = null;
+        }
         const root = document.getElementById("tabs");
         root.textContent = "";
         snapshot.tabs.forEach((tab, i) => {
@@ -255,7 +279,17 @@
             (tab.attention ? " attention" : "");
           el.draggable = true;
           el.dataset.index = i;
-          const profLabel = tab.profile ? " · profile: " + tab.profile : "";
+          // The dot is driven solely by the page-reported active-profile name
+          // (#31), which is authoritative: it shows the dot on the starting
+          // profile too, and correctly shows NO dot for the default profile —
+          // even a renamed root, or a tab carrying an explicit
+          // `hermes_profile=default` cookie. (We deliberately do NOT fall back
+          // to `tab.profile`, the cookie value: that resurrects a spurious dot
+          // for the default profile. `tab.profile` is kept only for restore
+          // re-seeding.) On Win/Linux the reporter always runs, so the dot is
+          // populated within a load; this code path never runs on macOS.
+          const prof = tab.dot_profile;
+          const profLabel = prof ? " · profile: " + prof : "";
           el.title =
             (tab.attention
               ? (tab.title || "New Tab") + " — waiting for you"
@@ -265,11 +299,11 @@
             dot.className = "attn";
             dot.setAttribute("aria-label", "waiting for you");
             el.appendChild(dot);
-          } else if (tab.profile) {
+          } else if (prof) {
             const pf = document.createElement("span");
             pf.className = "pf";
-            pf.style.background = profileColor(tab.profile);
-            pf.setAttribute("aria-label", "profile: " + tab.profile);
+            pf.style.background = profileColor(prof);
+            pf.setAttribute("aria-label", "profile: " + prof);
             el.appendChild(pf);
           }
           const t = document.createElement("span");


### PR DESCRIPTION
## What this is

A **v0.6.2 bug-squash** focused on fixes that are *genuinely* resolved this time — including two (`#30`/`#37`) that previous releases only *appeared* to fix. I evaluated every open issue independently, fixed the live bugs, then ran an **adversarial verification pass** on each fix (multiple angles + full tracing + live smoke-testing where possible). That pass found **four real holes in my own first-cut fixes**, which this PR then corrects. Details below so you can review the reasoning, not just the diff.

## ⚠️ The headline: why #30/#37 kept coming back

`#30` was marked fixed in v0.6.0 and `#37` in v0.6.1, yet both kept happening on Windows. Root cause (traced through wry + the WebUI server this round):

- The profile selector `hermes_profile` is a **session cookie** (no expiry — confirmed in `hermes-webui` `api/helpers.py:586`).
- **WebView2 discards session cookies** from a tab's on-disk data folder when the app restarts. So a restored tab — even reusing its data folder to keep you logged in — came back on the **default** profile.
- Its saved `/session/<id>` link is **profile-scoped**, so the server returns it not-found (`routes.py` `_session_visible_to_active_profile`) → "Session not available in web UI." → bounce to root.
- The earlier fixes were only ever validated on the **macOS forced-strip harness** (`HERMES_FORCE_STRIP=1`), which keeps the cookie in memory for the app's lifetime and so never reproduced the WebView2 behavior.

**Fix:** re-seed the saved profile cookie on restore, **pinned to the target host**. The host pin is the crux — `wry::WebView::set_cookie` takes no URL, so a domain-less cookie becomes `CreateCookie(.., domain="")` on WebView2 and is **silently never sent** (verified in `wry-0.55.1/src/webview2/mod.rs:1575`). That's why a naive re-seed compiles, runs, swallows no error, and does nothing on Windows. macOS native restore keeps the domain-less form WKWebView accepts, so it's left untouched.

## The adversarial pass — 4 holes found and fixed

I fanned out four independent skeptics (one per fix), each told to *refute* full resolution. They earned their keep:

| Hole | Severity | Fix in this PR |
|---|---|---|
| **#30/#37** re-seed used a **domain-less** cookie → dropped by WebView2 → fix was a no-op on Windows | Critical | Pin `set_domain(host)` on the re-seeded cookie |
| **#31** front-end `dot_profile \|\| tab.profile` fallback **resurrected a false dot** for the default profile (the WebUI persists `hermes_profile=default` on switch-to-default; also a renamed root) | High | Drop the cookie fallback (reporter is authoritative); filter the literal `"default"` from the seed |
| **#10** hint flag was **burned even if the toast was suppressed** (Focus Assist / notifications-off / dev build) → first-time hider permanently stuck | High | Retire the hint on the **un-hide** transition (proof the user learned Ctrl+Shift+B), not on hide |
| **#38** closing the tab being renamed left an **orphaned input** on a gone tab | Low | Release the rename + rebuild when the renamed tab leaves the snapshot |

(The #38 verifier also confirmed the headline "input vanishes while typing" is genuinely fixed and that the closing-a-tab-mid-rename path is near-unreachable in practice — any close action blurs the input first — but the guard is cheap insurance.)

## Issues fixed in this PR (5)

- **#30 + #37** — restored tab reopens on the right profile & real session instead of bouncing to home. (Root cause + fix above.)
- **#31** — per-tab profile dot correct on launch and never shown for the default profile. A page-side `/api/profile/active` reporter drives the dot authoritatively, instead of the cookie (which the WebUI sets only on an explicit switch).
- **#38** — renaming a tab no longer has the edit box vanish mid-keystroke. Emit `tabs-changed` only on a real change, and never rebuild the strip while a rename is open.
- **#10** — hiding the tab bar now shows an OS notification with the un-hide shortcut (the "⋯" button disappears with the bar, so first-timers had no affordance). (The "consolidate with the WebUI top bar" half of #10 remains an enhancement, not done here.)

## Every other open issue, triaged

- **#32** native notifications, **#26** dot-updates-on-switch, **#8** profile dot, **#7** rename, **#18** tab restore, **#19** drag-reorder, **#22** macOS one-tab drag — shipped/fixed in v0.4–v0.6.1; this PR builds on them (and #18 only truly works on Windows *with* the #30/#37 fix here).
- **#28** (502 behind a proxy on relaunch) — the per-tab boot retry added for #37 also helps the bounce case, but #28's specific "readiness probe accepts 5xx" concern was **not** re-verified this release; leaving open.
- **#5** (icon white fringe) — **deferred**: the interior near-white is shared with the logo glyph (sampled), so a recolor would damage the logo; needs corrected source art.
- **#9** (per-tab server connections), **#11** (portable user-level updater) — enhancements/feature requests, out of scope for a bug-squash.

## Verification

- ✅ `cargo fmt --check`, `cargo clippy` (clean), `cargo test` (14 pass, incl. `ssh_args_frozen`, `profile_cookie_matches_webui_attrs`).
- ✅ **Windows cross-compile** (`cargo xwin check --target x86_64-pc-windows-msvc`) — the WebView2 / notification / cookie paths compile.
- ✅ **Live smoke (macOS forced-strip)** of the #31 reporter chain against a fake `/api/profile/active`: non-default → dot, default → **no** dot, clean boot, no panic.

**Honest gap:** #30/#37's re-seed and #31's reporter are `cfg(not(target_os = "macos"))`, so their *runtime* behavior can't be exercised on this macOS box beyond the cross-compile, the live reporter smoke, and source-level tracing through wry + the WebUI server. The #30/#37 host-pin in particular wants a **real Windows restore test** (named profile + a `/session/<id>` tab, quit, reopen → lands on the session). Flagging it for that check before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
