### PR TITLE
v0.6.3 — profile color dot on every tab, default profile included (#8/#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.6.3] — 2026-06-19
+
+A small follow-up to v0.6.2's profile-dot work.
+
+### Changed
+
+- **Every tab shows a profile color dot — the default profile included**
+  (issues #8 / #31). v0.6.2 showed the dot only for non-default profiles, so a
+  tab on the default profile had none. Now every profile maps to its own stable
+  color, default and named alike: each tab carries its current profile's dot,
+  all tabs on the same profile share one color, and switching a tab's profile
+  recolors it immediately. Reopened tabs come back on the profile (and session)
+  you left them on, with the colors reloaded. The dot is driven by the page's
+  reported active profile (`/api/profile/active`), which is authoritative for
+  the default profile too, so it's reliable rather than guessed from a cookie.
+
 ## [v0.6.2] — 2026-06-19
 
 A bug-squash release centered on the Windows session-restore failures that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,9 @@
 
 ## [v0.6.3] — 2026-06-19
 
-A small follow-up to v0.6.2's profile-dot work.
-
-### Changed
-
-- **Every tab shows a profile color dot — the default profile included**
-  (issues #8 / #31). v0.6.2 showed the dot only for non-default profiles, so a
-  tab on the default profile had none. Now every profile maps to its own stable
-  color, default and named alike: each tab carries its current profile's dot,
-  all tabs on the same profile share one color, and switching a tab's profile
-  recolors it immediately. Reopened tabs come back on the profile (and session)
-  you left them on, with the colors reloaded. The dot is driven by the page's
-  reported active profile (`/api/profile/active`), which is authoritative for
-  the default profile too, so it's reliable rather than guessed from a cookie.
-
-## [v0.6.2] — 2026-06-19
-
-A bug-squash release centered on the Windows session-restore failures that
-earlier releases only appeared to fix — they were validated on the macOS
-forced-strip harness, which doesn't reproduce WebView2's cookie behavior, so
-they shipped still broken on Windows. This release traces and fixes the actual
-root cause.
+A bug-squash release: the Windows session-restore failures fixed at the real
+root cause, plus universal per-tab profile color dots. (Rolls up the v0.6.2 tag,
+which was never published — these changes ship together here.)
 
 ### Fixed
 
@@ -42,14 +24,6 @@ root cause.
   login and drafts still ride along in the reused data folder; only the profile
   selector is restored. (macOS was unaffected — its webview keeps the in-memory
   cookie for the life of the app.)
-- **Windows/Linux: the per-tab profile dot is now correct on launch and never
-  shows for the default profile** (issue #31, follow-on to v0.6.0). The dot was
-  driven by the profile *cookie*, which the WebUI sets only on an explicit
-  switch — so a tab that simply *started* on a named profile showed no dot, while
-  a tab switched back to the default profile (or a renamed root profile) showed a
-  spurious one. Each tab's page now reports its actual active profile and that
-  drives the dot directly: it appears on the starting profile, and the default
-  profile correctly shows nothing.
 - **Windows/Linux: renaming a tab no longer has the edit box vanish as you type**
   (issue #38). Double-clicking a tab opens an inline rename field, but the active
   tab's title changes constantly while a chat streams, and each change rebuilt the
@@ -62,6 +36,19 @@ root cause.
   restore it. Hiding it now shows an OS notification with the shortcut, and keeps
   reminding you on each hide until you've successfully brought the bar back at
   least once (so the hint isn't wasted if the notification was suppressed).
+
+### Changed
+
+- **Every tab shows a profile color dot — the default profile included**
+  (issues #8 / #31). The dot used to be driven by the profile *cookie*, which the
+  WebUI sets only on an explicit switch — so a tab that simply *started* on a
+  named profile showed no dot, and the default profile never showed one at all.
+  Now every profile maps to its own stable color, default and named alike: each
+  tab carries its current profile's dot, all tabs on the same profile share one
+  color, and switching a tab's profile recolors it. Reopened tabs come back on
+  the profile (and session) you left them on, with the colors reloaded. Driven by
+  the page's reported active profile (`/api/profile/active`), authoritative for
+  the default profile too, so it's reliable rather than guessed from a cookie.
 
 ## [v0.6.1] — 2026-06-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.6.2"
+version = "0.6.3"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -492,28 +492,44 @@ const ROUTE_REPORTER: &str = r##"
   })();
 "##;
 
-/// S15 — active-profile reporter (issue #31): report the tab's active profile
-/// NAME so the strip can show the profile dot on the STARTING profile, not just
-/// after a switch. The WebUI sets the `hermes_profile` cookie only on an
-/// explicit `/api/profile/switch` — never on boot — so the shell's cookie-based
-/// dot is blank for a tab sitting on its launch profile. The page always knows
-/// the name (`/api/profile/active` → `{name, is_default}`), so it reports it
-/// (empty for the default profile = no dot), debounced to fire only on change.
+/// S15 — active-profile reporter (issue #31; extended for #8 in v0.6.3): report
+/// the tab's active profile NAME so the strip can color the per-tab profile dot.
+/// EVERY profile gets a dot, the DEFAULT profile INCLUDED — each name maps to
+/// its own stable color (`profileColor`), so every tab on one profile shares a
+/// color and three profiles show three colors. The WebUI sets the
+/// `hermes_profile` cookie only on an explicit switch (never on boot), so the
+/// cookie can't drive this; `/api/profile/active` always returns the real
+/// active name (`{name, is_default}` — `name` is non-empty even for the
+/// default / renamed-root profile, via `get_active_profile_name`). Reported on
+/// load, on every client-side navigation (a profile switch routes, so the dot
+/// recolors at once), and on a 3s / focus backstop — debounced to fire only on
+/// change. `no-store` so a switch isn't masked by a cached response.
 const PROFILE_REPORTER: &str = r##"
   (function () {
     var last = null;
     var report = function () {
       try {
-        fetch('/api/profile/active', { credentials: 'same-origin' })
+        fetch('/api/profile/active', { credentials: 'same-origin', cache: 'no-store' })
           .then(function (r) { return r.ok ? r.json() : null; })
           .then(function (p) {
             if (!p) return;
-            var name = p.is_default ? '' : (p.name || '');
+            var name = p.name || '';
             if (name !== last) { last = name; EMIT('profile', name); }
           })
           .catch(function () {});
       } catch (e) {}
     };
+    var wrap = function (n) {
+      try {
+        var orig = history[n];
+        if (typeof orig === 'function') {
+          history[n] = function () { var r = orig.apply(this, arguments); report(); return r; };
+        }
+      } catch (e) {}
+    };
+    wrap('pushState'); wrap('replaceState');
+    window.addEventListener('popstate', report);
+    window.addEventListener('hashchange', report);
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', report);
     else report();
     setInterval(report, 3000);

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -682,18 +682,12 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
             title,
             attention: false,
             profile: seed_profile.clone(),
-            // Seed the dot from the profile we know at creation so a non-default
-            // tab shows it instantly (and degrades gracefully on a server too
-            // old to expose /api/profile/active); the page's active-profile
-            // reporter refines it after load (issue #31). Filter the literal
-            // "default": the WebUI persists `hermes_profile=default` on an
-            // explicit switch-to-default, but the default profile must show NO
-            // dot — the reporter (is_default) would blank it anyway, this just
-            // avoids the flash. `profile` keeps the raw value for re-seeding.
-            dot_profile: seed_profile
-                .as_deref()
-                .filter(|v| *v != "default")
-                .map(str::to_string),
+            // Seed the dot from the profile we know at creation so a tab with a
+            // cookie shows its color instantly; the page's active-profile
+            // reporter sets/refines it after load — including for the DEFAULT
+            // profile, which now gets its own colored dot like any other
+            // (issue #8/#31, v0.6.3). No filter: every profile shows a color.
+            dot_profile: seed_profile,
             partition: partition_id,
             custom_title,
         });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"

--- a/src/shell.html
+++ b/src/shell.html
@@ -192,8 +192,9 @@
       let renamingLabel = null; // the tab label being renamed (#38)
       let lastSnapshot = null; // most recent tabs snapshot, to re-apply after edit
 
-      // Stable-ish color for a profile name → its dot (issue #8). The default
-      // profile (no cookie) gets no dot.
+      // Stable color for a profile name → its dot (issue #8). Every profile —
+      // the default included (v0.6.3) — maps to its own color, so all tabs on
+      // one profile share a color and distinct profiles get distinct colors.
       function profileColor(name) {
         let h = 0;
         for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) >>> 0;
@@ -280,14 +281,14 @@
           el.draggable = true;
           el.dataset.index = i;
           // The dot is driven solely by the page-reported active-profile name
-          // (#31), which is authoritative: it shows the dot on the starting
-          // profile too, and correctly shows NO dot for the default profile —
-          // even a renamed root, or a tab carrying an explicit
-          // `hermes_profile=default` cookie. (We deliberately do NOT fall back
-          // to `tab.profile`, the cookie value: that resurrects a spurious dot
-          // for the default profile. `tab.profile` is kept only for restore
-          // re-seeding.) On Win/Linux the reporter always runs, so the dot is
-          // populated within a load; this code path never runs on macOS.
+          // (#31), which is authoritative: EVERY tab shows a dot colored by its
+          // current profile — the default profile included (v0.6.3) — and it
+          // recolors when the tab's profile changes. (We deliberately do NOT
+          // fall back to `tab.profile`, the cookie value, which is empty for a
+          // tab on its starting profile and so would miss tabs; `tab.profile`
+          // is kept only for restore re-seeding.) On Win/Linux the reporter
+          // always runs, so the dot is populated within a load; this code path
+          // never runs on macOS.
           const prof = tab.dot_profile;
           const profLabel = prof ? " · profile: " + prof : "";
           el.title =


### PR DESCRIPTION
## What this does

Makes the per-tab profile dot universal, per your spec: **every tab shows a color dot tied to its current profile — the default profile included.**

- **Default is just another profile with its own color** — not "no dot" (which is what v0.6.2 did).
- **Same profile → same color; distinct profiles → distinct colors.** Four tabs on the default = four dots, all the default's color; three tabs on three profiles = three colors.
- **Switch a tab's profile → its dot recolors** (the reporter re-fetches on the navigation a switch triggers, so it's prompt, with a 3s/focus backstop).
- **Reopen → every tab comes back on the profile + session it was on** (that's v0.6.2's restore), **with the colors reloaded** (the reporter repaints each tab's dot on launch).

## How

Three focused changes (no session-format change — the colors reload on launch, pop-in is fine):

- **`bridge.rs` (`PROFILE_REPORTER`)** — report the *real* active-profile name for every profile instead of blanking the default (`p.name` rather than `p.is_default ? '' : p.name`). The server's `/api/profile/active` always returns a non-empty `name` (`get_active_profile_name()`), including for the default / renamed-root profile, so it's authoritative — not guessed from a cookie the WebUI only sets on an explicit switch. Also re-fetch on client-side navigation (`pushState`/`replaceState`/`popstate`/`hashchange`) so a profile switch recolors at once, and `cache:'no-store'` so a switch isn't masked by a cached response.
- **`strip.rs`** — stop filtering the literal `"default"` out of the dot seed, so a tab with a default cookie shows its color immediately too.
- **`shell.html`** — comments only; `profileColor(name)` already maps any name (including `"default"`) to a stable color, and the render already draws a dot for any reported profile.

## Verification

- ✅ `cargo fmt`/`clippy` clean, `cargo test` (14 pass), **Windows cross-compile** clean.
- ✅ **Live smoke** (forced-strip, fake `/api/profile/active` → `{name:"default", is_default:true}`): the tab now gets `dot_profile -> Some("default")` → a colored default dot (previously suppressed). Re-confirmed the named-profile case still works.

## Sequencing

This builds on v0.6.2 (PR #39), which is currently a **draft** awaiting its Windows restore smoke + Publish. **Merge/release this only after v0.6.2 is published** — I'll cut `release.sh v0.6.3` then. (If v0.6.2 needs a tweak first, I'll rebase this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
