### PR TITLE
v0.6.5 — tab-strip + notification fixes + per-tab working indicator (#19, #46, #49, #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [v0.6.5] — 2026-06-22
+
+A bug-fix release for the Windows/Linux tab strip and notification discoverability.
+
+### Fixed
+
+- **Windows/Linux: dragging a tab now reorders it** (issue #19). The reorder
+  handlers shipped in v0.4.0 but never worked: the tab-strip webview didn't
+  disable wry's native OS drag-drop handler, so it intercepted the gesture and
+  the strip page never received the HTML5 `dragstart`/`drop` events (the same
+  root cause the #27 fix addressed for content webviews). The strip webview now
+  disables the native handler, so drag-to-reorder works. (macOS already reorders
+  via its native tab bar.)
+- **Windows/Linux: the per-profile color picker now has clear controls** (issue
+  #49, follow-up to v0.6.4's #47). Right-clicking a tab previously opened the
+  bare OS color dialog with no obvious way to apply or close it. It now opens a
+  small in-strip popover with one-click palette swatches, a custom-color input,
+  and explicit **Reset** (back to the auto color) and **Close** buttons (also
+  Escape / click-away). The chosen color still persists per profile.
+- **Notifications: the desktop toggle is now easier to find, with a pointer to
+  the second switch** (issue #50). The desktop Preferences notification toggle
+  now sits under its own "NOTIFICATIONS" heading and notes that notifications
+  must *also* be enabled in Hermes WebUI Settings → "Browser notifications" —
+  the WebUI-side gate a user had to discover separately before anything fired.
+
 ## [v0.6.4] — 2026-06-21
 
 A sweep focused on the per-tab profile dots — distinct, customizable, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## [v0.6.5] — 2026-06-22
 
-A bug-fix release for the Windows/Linux tab strip and notification discoverability.
+A bug-fix release for the Windows/Linux tab strip and notification discoverability,
+plus a per-tab "working" indicator.
+
+### Added
+
+- **Windows/Linux: tabs now show a "working" spinner while their session is
+  streaming** (issue #46). A small spinner appears on a tab whose session has a
+  run in flight (mirroring the web app's in-progress spinner), so with several
+  tabs open you can see at a glance which background tabs are busy. Driven by the
+  page's own busy state — the same signal as the in-app spinner — and clears the
+  moment the run finishes (the tab's profile dot / attention badge takes over
+  again).
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.6.4"
+version = "0.6.5"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -537,6 +537,31 @@ const PROFILE_REPORTER: &str = r##"
   })();
 "##;
 
+/// S16 — busy/streaming reporter (issue #46): watch the WebUI's `S.busy` flag —
+/// the same state that drives the web app's in-progress spinner — and report
+/// working/idle over the bridge, so the strip can show a per-tab "working"
+/// glyph (you can see which background tabs have a run in flight). `S` is a
+/// top-level `const` in the WebUI's classic, deferred `ui.js`, reachable as a
+/// free variable from this injected script (same page realm where the
+/// notification shim patches `window.Notification`). Polled at 700ms + on
+/// focus, debounced to emit only on change. The try/catch guards the brief
+/// pre-`ui.js` window where `S` is still in its temporal dead zone.
+const BUSY_REPORTER: &str = r##"
+  (function () {
+    var last = null;
+    var report = function () {
+      try {
+        var b = (typeof S !== 'undefined' && S) ? !!S.busy : false;
+        if (b !== last) { last = b; EMIT('busy', b); }
+      } catch (e) {}
+    };
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', report);
+    else report();
+    setInterval(report, 700);
+    window.addEventListener('focus', report);
+  })();
+"##;
+
 /// macOS-only profile reporter (issue #44). macOS uses native tabs with no
 /// strip, so there's nowhere to hang the Win/Linux color dot — surface the
 /// active profile in the native tab TITLE instead. Mirrors `PROFILE_REPORTER`
@@ -589,9 +614,10 @@ pub fn init_script(label: &str, pre_paint_hex: &str, is_ssh: bool) -> String {
     }
     if cfg!(not(target_os = "macos")) {
         parts.push(SHORTCUT_FORWARDER);
-        // Profile dot is strip-only (Windows/Linux); macOS native tabs have no
-        // dot, so skip the reporter's polling there (issue #31).
+        // Profile dot + working glyph are strip-only (Windows/Linux); macOS
+        // native tabs have no strip, so skip these reporters there (#31, #46).
         parts.push(PROFILE_REPORTER);
+        parts.push(BUSY_REPORTER);
     }
     parts.push(THEME_BRIDGE);
     parts.push(ROUTE_REPORTER);
@@ -660,6 +686,13 @@ pub fn install(app: &AppHandle) {
                 if crate::strip::enabled() && label.starts_with("tab-") {
                     let name = payload["value"].as_str().unwrap_or("").to_string();
                     crate::strip::set_tab_dot_profile(&handle, &label, &name);
+                }
+            }
+            // Tab busy/streaming state for the per-tab "working" glyph (#46).
+            "busy" => {
+                if crate::strip::enabled() && label.starts_with("tab-") {
+                    let busy = payload["value"].as_bool().unwrap_or(false);
+                    crate::strip::set_tab_busy(&handle, &label, busy);
                 }
             }
             // Active-profile NAME for the macOS native tab title (issue #44).

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -22,6 +22,12 @@ pub struct TabEntry {
     /// the strip renders an attention badge so a blocked background tab is
     /// findable without clicking through every tab.
     pub attention: bool,
+    /// This tab's session is actively streaming a response (issue #46). Reported
+    /// by the page's busy reporter watching the WebUI's `S.busy` flag — the same
+    /// state that drives the web app's in-progress spinner — so the strip can
+    /// show a per-tab "working" glyph and you can see which background tabs have
+    /// a run in flight. Transient: re-derived each launch, never persisted.
+    pub busy: bool,
     /// The active WebUI profile for this tab — the value of its per-tab
     /// `hermes_profile` cookie (None = the default profile). Read from the
     /// tab's isolated cookie jar after each real page load. Drives the strip's

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -688,6 +688,7 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
             label: tab_label.clone(),
             title,
             attention: false,
+            busy: false,
             profile: seed_profile.clone(),
             // Seed the dot from the profile we know at creation so a tab with a
             // cookie shows its color instantly; the page's active-profile
@@ -1063,6 +1064,34 @@ pub fn set_tab_dot_profile(app: &AppHandle, tab_label: &str, name: &str) {
         {
             Some(tab) if tab.dot_profile != value => {
                 tab.dot_profile = value;
+                true
+            }
+            _ => false,
+        }
+    };
+    if changed {
+        emit_tabs(app, &window_label);
+    }
+}
+
+/// Set a tab's busy (actively-streaming) flag (issue #46), reported by the
+/// page's busy reporter (the WebUI's `S.busy`). Emit-on-change so a streaming
+/// tab — whose `S.busy` is polled, not its constantly-mutating title — doesn't
+/// flood the strip. No webview read (just a bool from the bridge), so it's safe
+/// regardless of the menu modal loop (#33).
+pub fn set_tab_busy(app: &AppHandle, tab_label: &str, busy: bool) {
+    let Some(window_label) = window_of_tab(tab_label) else {
+        return;
+    };
+    let state = app.state::<AppState>();
+    let changed = {
+        let mut strip = state.strip.lock().unwrap();
+        match strip
+            .get_mut(&window_label)
+            .and_then(|e| e.tabs.iter_mut().find(|t| t.label == tab_label))
+        {
+            Some(tab) if tab.busy != busy => {
+                tab.busy = busy;
                 true
             }
             _ => false,

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -229,7 +229,14 @@ fn build_strip_window(
     let strip_label = format!("strip-{n}");
     let init = format!("window.__HERMES_WIN = '{label}';");
     let swb = WebviewBuilder::new(&strip_label, WebviewUrl::App("shell.html".into()))
-        .initialization_script(&init);
+        .initialization_script(&init)
+        // Drag-to-reorder tabs (#19) is HTML5 drag in shell.html. Without this,
+        // wry's native OS drag-drop handler intercepts the gesture and the page
+        // never sees dragstart/drop — so reorder silently no-ops on Windows
+        // (same root cause as #27 for content webviews). The strip hosts only
+        // the tab bar + ⋯ menu; it needs no native file-drop, and window-drag
+        // (data-tauri-drag-region) is a separate mechanism, unaffected.
+        .disable_drag_drop_handler();
     let scale = win.scale_factor().unwrap_or(1.0);
     let logical = win
         .inner_size()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"

--- a/src/prefs.html
+++ b/src/prefs.html
@@ -66,6 +66,12 @@
       .checkbox-row input {
         margin-top: 2px;
       }
+      .checkbox-row .hint {
+        display: block;
+        margin-top: 4px;
+        font-size: 11px;
+        color: var(--hermes-fg-secondary);
+      }
       hr {
         border: none;
         border-top: 1px solid var(--hermes-border);
@@ -131,12 +137,19 @@
       <label>Target URL</label>
       <input type="text" id="targetURL" placeholder="http://localhost:8787" />
     </div>
+    <div class="section">NOTIFICATIONS</div>
     <div class="checkbox-row">
       <span></span>
       <label>
         <input type="checkbox" id="notifications" />
-        Show a notification when a response completes while the app is in the
-        background
+        <span>
+          Show a native notification when a response completes while the app is
+          in the background.
+          <span class="hint"
+            >Notifications must also be enabled in Hermes WebUI Settings →
+            “Browser notifications” for them to fire.</span
+          >
+        </span>
       </label>
     </div>
     <div class="footer">

--- a/src/shell.html
+++ b/src/shell.html
@@ -96,6 +96,73 @@
         border-radius: 50%;
         box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
       }
+      /* Per-profile color popover (issue #49): swatches + custom + reset/close,
+         with explicit affordances (the bare native picker had none). */
+      .colorpop {
+        position: fixed;
+        z-index: 50;
+        width: 176px;
+        padding: 9px;
+        background: var(--hermes-control-bg, #2a2a2a);
+        border: 1px solid var(--hermes-border, #444);
+        border-radius: 8px;
+        box-shadow: 0 6px 22px rgba(0, 0, 0, 0.45);
+        color: var(--hermes-fg, #eee);
+        font-size: 11px;
+      }
+      .colorpop .cp-head {
+        font-weight: 600;
+        margin-bottom: 7px;
+        color: var(--hermes-fg-secondary, #aaa);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .colorpop .cp-grid {
+        display: grid;
+        grid-template-columns: repeat(6, 1fr);
+        gap: 6px;
+        margin-bottom: 9px;
+      }
+      .colorpop .cp-sw {
+        width: 19px;
+        height: 19px;
+        padding: 0;
+        border-radius: 50%;
+        border: 2px solid transparent;
+        cursor: pointer;
+      }
+      .colorpop .cp-sw.sel {
+        border-color: var(--hermes-fg, #fff);
+      }
+      .colorpop .cp-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .colorpop .cp-custom {
+        flex: none;
+        width: 24px;
+        height: 22px;
+        padding: 0;
+        border: 1px solid var(--hermes-border, #444);
+        border-radius: 5px;
+        background: transparent;
+        cursor: pointer;
+      }
+      .colorpop .cp-btn {
+        flex: 1;
+        padding: 3px 6px;
+        font-size: 11px;
+        border: 1px solid var(--hermes-border, #444);
+        border-radius: 5px;
+        background: var(--hermes-bg, #1a1a1a);
+        color: var(--hermes-fg, #eee);
+        cursor: pointer;
+      }
+      .colorpop .cp-btn:hover {
+        border-color: var(--hermes-accent, #0a84ff);
+      }
       /* Drag-to-reorder (issue #19) */
       .tab.dragging {
         opacity: 0.45;
@@ -236,6 +303,92 @@
         return PROFILE_PALETTE[h % PROFILE_PALETTE.length];
       }
 
+      // Per-profile color popover (issue #49). Replaces the old bare
+      // <input type=color> (which had no obvious confirm/close) with a small
+      // in-strip popover: palette swatches (one-click apply), a custom-color
+      // input, and explicit Reset/Close. All persist via `set_profile_color`
+      // (empty color clears the override → back to the auto palette).
+      function closeColorPopover() {
+        const p = document.querySelector(".colorpop");
+        if (p) p.remove();
+        document.removeEventListener("mousedown", onColorPopDown, true);
+        document.removeEventListener("keydown", onColorPopKey, true);
+      }
+      function onColorPopDown(e) {
+        if (!e.target.closest(".colorpop")) closeColorPopover();
+      }
+      function onColorPopKey(e) {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          closeColorPopover();
+        }
+      }
+      function applyProfileColor(prof, color, close) {
+        hermes.invoke("set_profile_color", { name: prof, color: color });
+        if (color) profileColors[prof] = color;
+        else delete profileColors[prof];
+        if (lastSnapshot) renderTabs(lastSnapshot); // instant feedback
+        if (close !== false) closeColorPopover();
+      }
+      function openColorPopover(prof, x, y) {
+        closeColorPopover(); // single instance
+        const current = (profileColor(prof) || "").toLowerCase();
+        const pop = document.createElement("div");
+        pop.className = "colorpop";
+
+        const head = document.createElement("div");
+        head.className = "cp-head";
+        head.textContent = "Color · " + prof;
+        pop.appendChild(head);
+
+        const grid = document.createElement("div");
+        grid.className = "cp-grid";
+        PROFILE_PALETTE.forEach((c) => {
+          const sw = document.createElement("button");
+          sw.className = "cp-sw" + (c.toLowerCase() === current ? " sel" : "");
+          sw.style.background = c;
+          sw.title = c;
+          sw.addEventListener("click", () => applyProfileColor(prof, c));
+          grid.appendChild(sw);
+        });
+        pop.appendChild(grid);
+
+        const row = document.createElement("div");
+        row.className = "cp-row";
+        const custom = document.createElement("input");
+        custom.type = "color";
+        custom.className = "cp-custom";
+        custom.value = current || "#888888";
+        custom.title = "Custom color…";
+        // `change` fires once the OS picker commits (not per drag tick).
+        custom.addEventListener("change", () => applyProfileColor(prof, custom.value));
+        const reset = document.createElement("button");
+        reset.className = "cp-btn";
+        reset.textContent = "Reset";
+        reset.title = "Revert to the automatic color";
+        reset.addEventListener("click", () => applyProfileColor(prof, ""));
+        const close = document.createElement("button");
+        close.className = "cp-btn";
+        close.textContent = "Close";
+        close.addEventListener("click", closeColorPopover);
+        row.appendChild(custom);
+        row.appendChild(reset);
+        row.appendChild(close);
+        pop.appendChild(row);
+
+        document.body.appendChild(pop);
+        // Clamp within the viewport (the strip is short, so prefer below).
+        const w = pop.offsetWidth || 176;
+        const h = pop.offsetHeight || 90;
+        pop.style.left = Math.max(4, Math.min(x, window.innerWidth - w - 6)) + "px";
+        pop.style.top = Math.min(y, window.innerHeight - h - 6) + "px";
+        // Defer listener attach so this same click doesn't immediately close it.
+        setTimeout(() => {
+          document.addEventListener("mousedown", onColorPopDown, true);
+          document.addEventListener("keydown", onColorPopKey, true);
+        }, 0);
+      }
+
       function clearDropMarks() {
         document
           .querySelectorAll(".tab.drop-before, .tab.drop-after")
@@ -373,25 +526,13 @@
               hermes.invoke("tab_close", { window: WIN, tab: tab.label });
           });
           // Right-click a tab to set a custom color for its profile (issue #47).
-          // The color is per-PROFILE (not per-tab), so every tab on that profile
-          // recolors. Opens the OS color picker seeded with the current color;
-          // the chosen color is persisted in app prefs over the bridge.
+          // The color is per-PROFILE, so every tab on that profile recolors.
+          // Opens an in-strip popover with explicit affordances (issue #49): the
+          // bare native picker had no obvious confirm/close.
           el.addEventListener("contextmenu", (e) => {
             if (!prof) return;
             e.preventDefault();
-            const picker = document.createElement("input");
-            picker.type = "color";
-            picker.value = profileColor(prof);
-            picker.style.cssText =
-              "position:fixed;left:" + e.clientX + "px;top:" + e.clientY +
-              "px;width:1px;height:1px;opacity:0;border:0;padding:0";
-            document.body.appendChild(picker);
-            picker.addEventListener("change", () => {
-              hermes.invoke("set_profile_color", { name: prof, color: picker.value });
-              picker.remove();
-            });
-            picker.addEventListener("blur", () => picker.remove());
-            picker.click();
+            openColorPopover(prof, e.clientX, e.clientY);
           });
 
           // Drag-to-reorder (issue #19).

--- a/src/shell.html
+++ b/src/shell.html
@@ -96,6 +96,22 @@
         border-radius: 50%;
         box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
       }
+      /* Per-tab "working" spinner (issue #46): shown while the tab's session is
+         actively streaming, mirroring the web app's in-progress spinner. */
+      .tab .working {
+        flex: none;
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        border: 1.5px solid var(--hermes-fg-secondary, #888);
+        border-top-color: transparent;
+        animation: hermes-spin 0.7s linear infinite;
+      }
+      @keyframes hermes-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
       /* Per-profile color popover (issue #49): swatches + custom + reset/close,
          with explicit affordances (the bare native picker had none). */
       .colorpop {
@@ -484,11 +500,22 @@
           // (review follow-up). Both recolor on a switch. (Never runs on macOS.)
           const prof = profileName(tab.profile) || tab.dot_profile;
           const profLabel = prof ? " · profile: " + prof : "";
-          el.title =
-            (tab.attention
-              ? (tab.title || "New Tab") + " — waiting for you"
-              : tab.title || "New Tab") + profLabel;
-          if (tab.attention) {
+          const stateLabel = tab.busy
+            ? " — working"
+            : tab.attention
+              ? " — waiting for you"
+              : "";
+          el.title = (tab.title || "New Tab") + stateLabel + profLabel;
+          // Leading decoration, highest-priority first: a working session shows
+          // a spinner (#46); a blocked one shows the attention badge (#14);
+          // otherwise the per-tab profile dot (#8). A run finishing flips busy
+          // off, so attention/profile take over once it clears.
+          if (tab.busy) {
+            const sp = document.createElement("span");
+            sp.className = "working";
+            sp.setAttribute("aria-label", "working");
+            el.appendChild(sp);
+          } else if (tab.attention) {
             const dot = document.createElement("span");
             dot.className = "attn";
             dot.setAttribute("aria-label", "waiting for you");


### PR DESCRIPTION
## What this is

A v0.6.5 bug-fix release. I re-reviewed every open issue, closed the one now verifiably complete (**#45**), and fixed the three that are cleanly, verifiably fixable on the desktop side. The rest of the open set is triaged at the bottom (most are WebUI-side or would-regress — not responsibly includable in a desktop-only release).

## Fixed

- **#19 — Windows/Linux: drag-to-reorder tabs now actually works.** The reorder handlers shipped in v0.4.0 but were dead on Windows/Linux: the tab-strip webview never called `.disable_drag_drop_handler()`, so wry's native OS drag-drop handler intercepted the gesture and the strip page never saw the HTML5 `dragstart`/`drop` events — the *exact* root cause the #27 fix handled for content webviews, just never applied to the strip shell webview. One-line fix at the strip webview builder (`strip.rs`). (macOS reorders via its native tab bar, a different path.)
- **#49 — the per-profile color picker has clear controls.** v0.6.4's right-click picker just `.click()`d a hidden `<input type="color">`, so users got the bare OS color dialog with no obvious apply/close (only "click away" dismissed it). Replaced with a small in-strip popover: one-click palette swatches, a custom-color input, and explicit **Reset** (→ auto color) / **Close** (+ Escape / click-away). Backend unchanged — still persists via `set_profile_color` (which clears on a non-hex value).
- **#50 — the desktop notifications toggle is discoverable, and points at the second gate.** The toggle already existed in Preferences but was buried and gave no hint that notifications *also* require the WebUI's own "Browser notifications" setting (the switch a user had to find before anything fired). It now sits under its own **NOTIFICATIONS** heading with that pointer.

## Closed (verified complete)
- **#45** (dots collapse after restart) — resolved by v0.6.4's per-tab-cookie dot (structurally can't collapse) **and** the WebUI root-cause fix #4586 (closed). Commented + closed.

## Verification
- `cargo fmt`/`clippy` clean, **18 tests** pass, **Windows cross-compile** clean.
- Forced-strip boots clean with the shell.html changes; `shell.html` script syntax-checked (`node --check`). #19's true bug is WebView2-specific, so a Windows artifact is the authoritative check, but the fix mirrors the proven #27 pattern.

## Triaged but NOT included (with reasons)
- **WebUI-side (out of scope for a desktop release):** **#52** (default workspace / mid-turn switch — confirmed WebUI app logic), **#53** (stale model dropdown — confirmed the WebUI's profile-scoped server-side model cache; `/api/models` is already `no-store` in the webview), and most of **#51** (the in-page approval cards re-surface per session = server state).
- **Would regress / needs WebUI coordination:** **#32** (background-tab notifications) — the only desktop lever is forcing `document.hidden` on hidden tabs, which would trip the WebUI's *close-SSE-on-hidden* logic and break the "hidden tabs stay alive" guarantee. Needs a desktop-aware notify path in the WebUI.
- **Needs a wry fork / page-side change:** **#43** (macOS WKWebView drop) — wry 0.55 can't split "don't swallow OS file-drops" from "deliver in-page HTML5 drops" on WKWebView; not fixable here without a fork or a hermes-webui MIME change (and unverifiable without manual drag testing).
- **Needs source art:** **#5** (icon corner fringe) — the source is a pre-rounded badge with a baked light rim; the clean fix is a full-bleed square master (none in-repo). No safe pixel-only transform (the rim is entangled with the gradient + the chrome logo).
- **Windows-unverifiable, reported case already covered:** **#37** (restore "Session not available") — v0.6.3's host-pinned re-seed + 2.5s retry already cover the reported hostname/proxy case; the residual `Domain=localhost`/IP concern is medium-risk and needs a real Windows test, not a blind change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
