### PR TITLE
v0.6.6 — background-tab notifications, macOS Show-All-Tabs, download Save dialog, profile-colored spinner (#32, #42, #57, #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [v0.6.6] — 2026-06-24
+
+A batch of bug fixes and features: background-tab notifications, a Mac-native
+tab-bar menu, a download save dialog, and a profile-colored working spinner.
+
+### Added
+
+- **macOS: Window ▸ Show All Tabs (⌃⌘T) summons the native tab bar** even with
+  one window open (issue #42). macOS only shows the tab bar once you have two
+  tabs, so tabs were easy to miss — this is the Mac-native menu affordance that
+  completes the discoverability work begun in v0.6.4 (the first-run ⌘T hint).
+
+### Fixed
+
+- **Background tabs now fire OS notifications** (issue #32, with hermes-webui
+  #4753). A tab that wasn't the visible one never fired its completion/approval
+  notification: the WebUI gates notifications on `document.hidden`, and a hidden
+  tab's webview still reports visible. The shell now tells the page when its tab
+  is backgrounded — on tab switch, and when the whole app loses focus — and the
+  WebUI honors that for notifications only, so a background tab notifies *and*
+  keeps streaming. (Needs a hermes-webui new enough to include the notification
+  hook, v0.51.612+; on older servers it harmlessly no-ops as before.)
+- **A working tab keeps its profile color** (issue #55). v0.6.5's per-tab
+  "working" spinner hid the profile color dot while a run streamed; the spinner
+  is now tinted with the profile's color, so a busy tab still shows which
+  profile it's on.
+- **Workspace-file downloads show a Save dialog and reveal the file** (issue #57,
+  macOS/Linux). Downloads from the workspace tree used to save silently into
+  ~/Downloads with no destination choice or clear feedback. The app now opens a
+  native Save panel (choose the location + name), then notifies on completion
+  and reveals the file in Finder/Files. (Windows already used WebView2's own
+  Save dialog.)
+
 ## [v0.6.5] — 2026-06-22
 
 A bug-fix release for the Windows/Linux tab strip and notification discoverability,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ tab-bar menu, a download save dialog, and a profile-colored working spinner.
 
 ### Added
 
-- **macOS: Window ▸ Show All Tabs (⌃⌘T) summons the native tab bar** even with
+- **macOS: Window ▸ Show Tab Bar (⌃⌘T) summons the native tab bar** even with
   one window open (issue #42). macOS only shows the tab bar once you have two
   tabs, so tabs were easy to miss — this is the Mac-native menu affordance that
   completes the discoverability work begun in v0.6.4 (the first-run ⌘T hint).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes-webui-desktop",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "scripts": {
     "tauri": "tauri"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.6.5"
+version = "0.6.6"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -802,8 +802,10 @@ pub fn install(app: &AppHandle) {
     });
 }
 
-/// Save intercepted download bytes into ~/Downloads with collision-safe
-/// naming, then notify (mac/linux — see DOWNLOAD_BRIDGE).
+/// Save intercepted download bytes (mac/linux — see DOWNLOAD_BRIDGE). Opens a
+/// native Save panel so the user picks the destination + filename (issue #57 —
+/// it used to save silently into ~/Downloads with no picker and no clear
+/// feedback), then writes, notifies, and reveals the file in Finder/Files.
 fn save_download(app: &AppHandle, name: &str, bytes: &[u8]) {
     let safe: String = name
         .chars()
@@ -816,47 +818,49 @@ fn save_download(app: &AppHandle, name: &str, bytes: &[u8]) {
         })
         .collect();
     let safe = safe.trim().trim_start_matches('.');
-    let safe = if safe.is_empty() { "download" } else { safe };
-    let Ok(dir) = app.path().download_dir() else {
-        log::warn!("download: no download dir");
-        return;
-    };
-    let mut target = dir.join(safe);
-    let mut counter = 1;
-    while target.exists() {
-        let stem = std::path::Path::new(safe)
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .unwrap_or("download");
-        let ext = std::path::Path::new(safe)
-            .extension()
-            .and_then(|s| s.to_str())
-            .map(|e| format!(".{e}"))
-            .unwrap_or_default();
-        target = dir.join(format!("{stem} ({counter}){ext}"));
-        counter += 1;
-    }
-    match std::fs::write(&target, bytes) {
-        Ok(()) => {
-            log::info!(
-                "download: saved {} ({} bytes)",
-                target.display(),
-                bytes.len()
-            );
-            let shown = target
-                .file_name()
-                .and_then(|s| s.to_str())
-                .unwrap_or(safe)
-                .to_string();
-            let _ = app
-                .notification()
-                .builder()
-                .title("Download complete")
-                .body(format!("Saved {shown} to Downloads"))
-                .show();
+    let safe = if safe.is_empty() { "download" } else { safe }.to_string();
+    let app = app.clone();
+    let bytes = bytes.to_vec();
+    // Off the main thread: blocking_save_file dispatches the panel to the main
+    // thread and blocks the caller, so it must not run on the UI thread.
+    std::thread::spawn(move || {
+        use tauri_plugin_dialog::DialogExt;
+        use tauri_plugin_opener::OpenerExt;
+        let mut builder = app.dialog().file().set_file_name(safe.clone());
+        if let Ok(dir) = app.path().download_dir() {
+            builder = builder.set_directory(dir);
         }
-        Err(e) => log::error!("download: write failed: {e}"),
-    }
+        let Some(target) = builder
+            .blocking_save_file()
+            .and_then(|fp| fp.into_path().ok())
+        else {
+            log::info!("download: save cancelled");
+            return;
+        };
+        match std::fs::write(&target, &bytes) {
+            Ok(()) => {
+                log::info!(
+                    "download: saved {} ({} bytes)",
+                    target.display(),
+                    bytes.len()
+                );
+                let shown = target
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(&safe)
+                    .to_string();
+                let _ = app
+                    .notification()
+                    .builder()
+                    .title("Download complete")
+                    .body(format!("Saved {shown}"))
+                    .show();
+                // Reveal in Finder/Explorer/Files so the user can find it.
+                let _ = app.opener().reveal_item_in_dir(&target);
+            }
+            Err(e) => log::error!("download: write failed: {e}"),
+        }
+    });
 }
 
 /// hermesTheme handler port: parse → luminance → appearance fan-out + persist.

--- a/src-tauri/src/macos.rs
+++ b/src-tauri/src/macos.rs
@@ -85,6 +85,25 @@ pub fn add_tabbed_window(host: &WebviewWindow, new_win: &WebviewWindow) {
     });
 }
 
+/// Toggle the window's native tab bar — the AppKit "Show/Hide Tab Bar" action
+/// (issue #42). For a single-window tab group this is the only way to summon the
+/// bar (NSWindowTabGroup has no `setTabBarVisible:` setter). GCD-deferred like
+/// `add_tabbed_window`: toggling the bar forces a relayout, and a forced display
+/// inside a tao callout self-deadlocks the main thread (invariant #12). The 1s
+/// chrome poller (`windows::refresh_macos_chrome`) re-fits the webview after.
+pub fn toggle_tab_bar(window: &WebviewWindow) {
+    let window = window.clone();
+    dispatch_main_async(move || {
+        if let Ok(ptr) = window.ns_window() {
+            unsafe {
+                let ns: &NSWindow = &*(ptr as *const NSWindow);
+                ns.toggleTabBar(None);
+            }
+        }
+        log::info!("macos: toggled tab bar on {}", window.label());
+    });
+}
+
 /// Set NSWindow.tabbingMode. `disallowed=true` before showing a Cmd+N window
 /// keeps it standalone; restore preferred afterwards (Swift fix).
 pub fn set_tabbing_mode(window: &WebviewWindow, disallowed: bool) {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -480,7 +480,7 @@ fn main() {
             // helper queues onto the GCD main queue (invariant #12) and returns
             // at once, so this menu callout never touches AppKit inline.
             #[cfg(target_os = "macos")]
-            "show_all_tabs" => {
+            "show_tab_bar" => {
                 if let Some(w) = windows::focused_or_recent_content(app) {
                     macos::toggle_tab_bar(&w);
                 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -546,7 +546,7 @@ fn main() {
                     if strip::enabled() {
                         strip::set_active_tab_backgrounded(app, label, bg);
                     } else if let Some(wv) = app.get_webview_window(label) {
-                        let _ = wv.eval(&format!(
+                        let _ = wv.eval(format!(
                             "window.__hermesSetBackgrounded&&window.__hermesSetBackgrounded({bg})"
                         ));
                     }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -337,6 +337,36 @@ fn main() {
                     });
                 }
             }
+            // Test hook: drive the Show-All-Tabs toggle (#42) from the main
+            // thread, then heartbeat — guards the invariant-#12 GCD path for the
+            // `toggleTabBar:` NSWindow mutation (a frozen main thread = missing
+            // heartbeats). Inert unless HERMES_TEST_TOGGLE_TABBAR=<seconds>.
+            #[cfg(target_os = "macos")]
+            if let Ok(v) = std::env::var("HERMES_TEST_TOGGLE_TABBAR") {
+                if let Ok(secs) = v.parse::<u64>() {
+                    let h = handle.clone();
+                    std::thread::spawn(move || {
+                        std::thread::sleep(std::time::Duration::from_secs(secs));
+                        let h2 = h.clone();
+                        let _ = h.run_on_main_thread(move || {
+                            if let Some(w) = windows::focused_or_recent_content(&h2) {
+                                macos::toggle_tab_bar(&w);
+                                log::info!("test: toggle-tabbar hook dispatched on main");
+                            }
+                        });
+                        for i in 1..=8u32 {
+                            std::thread::sleep(std::time::Duration::from_secs(2));
+                            let h3 = h.clone();
+                            let _ = h.run_on_main_thread(move || {
+                                log::info!(
+                                    "test: heartbeat {i} windows={}",
+                                    windows::content_window_handles(&h3).len()
+                                );
+                            });
+                        }
+                    });
+                }
+            }
             // Passive update check shortly after launch (Sparkle parity) —
             // never blocks startup; only surfaces a dialog when an update
             // actually exists.
@@ -446,6 +476,15 @@ fn main() {
                 let _ = tauri_plugin_opener::open_url(url, None::<&str>);
             }
             "show_main" => windows::show_most_recent(app),
+            // macOS: summon the native tab bar with one window open (#42). The
+            // helper queues onto the GCD main queue (invariant #12) and returns
+            // at once, so this menu callout never touches AppKit inline.
+            #[cfg(target_os = "macos")]
+            "show_all_tabs" => {
+                if let Some(w) = windows::focused_or_recent_content(app) {
+                    macos::toggle_tab_bar(&w);
+                }
+            }
             _ => {}
         })
         .on_window_event(|window, event| match event {
@@ -491,6 +530,27 @@ fn main() {
             tauri::WindowEvent::Moved(_) => {
                 let app = window.app_handle();
                 windows::persist_first_frame(app, window);
+            }
+            tauri::WindowEvent::Focused(focused) => {
+                // Tell the page when its tab is backgrounded so the WebUI fires
+                // OS notifications for an unfocused-but-streaming tab (#32). On
+                // macOS each native tab is its own window, so window focus IS the
+                // tab-switch signal; on the Win/Linux strip this catches the
+                // whole app losing/gaining focus (per-tab switching is handled in
+                // strip::select_tab). The flag feeds only the notification gate,
+                // not SSE-close, so streams keep running (hermes-webui #4753).
+                let app = window.app_handle();
+                let label = window.label();
+                if label.starts_with("main-") {
+                    let bg = !*focused;
+                    if strip::enabled() {
+                        strip::set_active_tab_backgrounded(app, label, bg);
+                    } else if let Some(wv) = app.get_webview_window(label) {
+                        let _ = wv.eval(&format!(
+                            "window.__hermesSetBackgrounded&&window.__hermesSetBackgrounded({bg})"
+                        ));
+                    }
+                }
             }
             _ => {}
         })

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -107,7 +107,7 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         // Mac-native tab discoverability (issue #42): summon the native tab bar
         // even with one window open (it otherwise only appears with 2+ tabs).
         .item(
-            &MenuItemBuilder::with_id("show_all_tabs", "Show All Tabs")
+            &MenuItemBuilder::with_id("show_tab_bar", "Show Tab Bar")
                 .accelerator("Ctrl+Cmd+T")
                 .build(app)?,
         )

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -104,6 +104,13 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
                 .build(app)?,
         )
         .separator()
+        // Mac-native tab discoverability (issue #42): summon the native tab bar
+        // even with one window open (it otherwise only appears with 2+ tabs).
+        .item(
+            &MenuItemBuilder::with_id("show_all_tabs", "Show All Tabs")
+                .accelerator("Ctrl+Cmd+T")
+                .build(app)?,
+        )
         .minimize()
         .build()?;
 

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -749,7 +749,7 @@ fn url_is_root(u: &str) -> bool {
 /// notification gate ONLY (not the SSE-close-on-hidden path), so a background
 /// tab notifies AND keeps streaming. No-op until the page defines it.
 fn set_tab_backgrounded(wv: &Webview<Wry>, backgrounded: bool) {
-    let _ = wv.eval(&format!(
+    let _ = wv.eval(format!(
         "window.__hermesSetBackgrounded&&window.__hermesSetBackgrounded({backgrounded})"
     ));
 }

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -681,6 +681,7 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
         if let Some(prev) = entry.tabs.get(entry.active) {
             if let Some(prev_wv) = find_webview(&win, &prev.label) {
                 let _ = prev_wv.hide();
+                set_tab_backgrounded(&prev_wv, true); // hidden by the new tab (#32)
             }
         }
         let title = custom_title.clone().unwrap_or_else(|| "New Tab".into());
@@ -740,6 +741,42 @@ fn url_is_root(u: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Tell a tab's page whether it's backgrounded (issue #32). The WebUI gates OS
+/// notifications on `document.hidden`, but a strip tab hidden via `wv.hide()`
+/// still reports visible — so a hidden-but-streaming tab never fired its
+/// completion/approval notification. The WebUI exposes
+/// `window.__hermesSetBackgrounded(bool)` (hermes-webui #4753), which feeds the
+/// notification gate ONLY (not the SSE-close-on-hidden path), so a background
+/// tab notifies AND keeps streaming. No-op until the page defines it.
+fn set_tab_backgrounded(wv: &Webview<Wry>, backgrounded: bool) {
+    let _ = wv.eval(&format!(
+        "window.__hermesSetBackgrounded&&window.__hermesSetBackgrounded({backgrounded})"
+    ));
+}
+
+/// Mark a strip window's currently-visible tab backgrounded/foregrounded (#32),
+/// used when the whole window gains/loses OS focus (app switch) — so a run
+/// completing in the active tab while the app is in the background still
+/// notifies. Hidden tabs are already flagged backgrounded by `select_tab`.
+pub fn set_active_tab_backgrounded(app: &AppHandle, window_label: &str, backgrounded: bool) {
+    let Some(win) = app.windows().get(window_label).cloned() else {
+        return;
+    };
+    let active = {
+        let state = app.state::<AppState>();
+        let strip = state.strip.lock().unwrap();
+        strip
+            .get(window_label)
+            .and_then(|e| e.tabs.get(e.active))
+            .map(|t| t.label.clone())
+    };
+    if let Some(label) = active {
+        if let Some(wv) = find_webview(&win, &label) {
+            set_tab_backgrounded(&wv, backgrounded);
+        }
+    }
+}
+
 pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
     let Some(win) = app.windows().get(window_label).cloned() else {
         return;
@@ -764,6 +801,7 @@ pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         if prev != tab_label {
             if let Some(wv) = find_webview(&win, &prev) {
                 let _ = wv.hide();
+                set_tab_backgrounded(&wv, true); // now backgrounded (#32)
             }
         }
     }
@@ -778,6 +816,7 @@ pub fn select_tab(app: &AppHandle, window_label: &str, tab_label: &str) {
         }
         let _ = wv.show();
         let _ = wv.set_focus();
+        set_tab_backgrounded(&wv, false); // now foreground (#32)
     }
     emit_tabs(app, window_label);
     refresh_window_title(app, window_label);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"

--- a/src/shell.html
+++ b/src/shell.html
@@ -513,7 +513,14 @@
           if (tab.busy) {
             const sp = document.createElement("span");
             sp.className = "working";
-            sp.setAttribute("aria-label", "working");
+            // Tint the spinner ring with the tab's profile color (#55) so a
+            // working tab still shows *which* profile it's on — the busy glyph
+            // no longer hides the per-profile color while a run is in flight.
+            if (prof) {
+              sp.style.borderColor = profileColor(prof);
+              sp.style.borderTopColor = "transparent";
+            }
+            sp.setAttribute("aria-label", prof ? "working · " + prof : "working");
             el.appendChild(sp);
           } else if (tab.attention) {
             const dot = document.createElement("span");


### PR DESCRIPTION
## What this is

A larger batch: I re-reviewed every open issue, closed the resolved ones, checked the WebUI repo for landed blockers that unlock desktop work, and packed in four fixes/features.

## The WebUI unlock (the headline)
Three of the blockers I filed last round have shipped in `hermes-webui`:
- **#4753 closed** → unlocked **#32** (I implement the desktop companion below).
- **#4755 closed** (v0.51.612) → resolves **#52** upstream.
- **#4756 closed** (v0.51.615) → resolves **#53** upstream.

(#4754 and #4757 are still open, so #51 and #43 stay blocked.)

## Fixed / Added (4)

- **#32 — background tabs now fire OS notifications.** A non-visible tab never fired its completion/approval notification, because the WebUI gates on `document.hidden` and a hidden tab's webview still reports visible. The WebUI shipped exactly the contract I proposed (`window.__hermesSetBackgrounded(bool)`, verified to feed the notification gate **only**, not SSE-close). The shell now calls it on tab switch (`strip::select_tab`/`add_tab`) and on app focus change (a new `WindowEvent::Focused` arm, both platforms) — so a background tab notifies *and* keeps streaming. No-ops harmlessly on a WebUI older than v0.51.612.
- **#42 — macOS Window ▸ Show All Tabs (⌃⌘T).** Summons the native tab bar with one window open (it otherwise only appears with 2+ tabs) — the Mac-native menu half of the discoverability work begun in v0.6.4. Implemented via `macos::toggle_tab_bar` → `NSWindow.toggleTabBar:`, **GCD-deferred** through `dispatch_main_async` (invariant #12, the freeze class). **Verified live**: a new `HERMES_TEST_TOGGLE_TABBAR` heartbeat hook drove the toggle and all 8 main-thread heartbeats continued afterward — no deadlock.
- **#57 — workspace downloads get a Save dialog + reveal.** Downloads used to save silently into ~/Downloads with no destination choice or feedback. Now a native Save panel (tauri-plugin-dialog, off the main thread) lets you pick location + name, then a completion notification fires and the file is revealed in Finder/Files (tauri-plugin-opener). mac/Linux (Windows already uses WebView2's own dialog).
- **#55 — a working tab keeps its profile color.** v0.6.5's per-tab "working" spinner hid the profile dot while streaming; the spinner is now tinted with the profile's color, so you still see which profile a busy tab is on.

## Closed (resolved) this round
- **#19, #46, #49, #50** — shipped in v0.6.5 (auto-close hadn't fired).
- **#52, #53** — resolved upstream (hermes-webui #4755 / #4756); no desktop change. Commented + closed.

## Verification
- `cargo fmt`/`clippy` clean, **18 tests**, **Windows cross-compile** clean.
- `shell.html` JS syntax-checked; forced-strip boots clean (shell.html + the #32 evals run without crashing); **#42 toggle deadlock-guarded live** on a real macOS build.
- Manual checks worth doing before publish: a real **download** on macOS (the native Save panel can't be auto-driven here), and **#32** end-to-end against a v0.51.612+ server (background tab → completion → OS notification).

## Still open / not in this release
- **#56** (cross-tab upgrade prompt) — **WebUI-side**: the `#updateBanner` is gated by per-webview `sessionStorage`, and the strip's tabs are storage-isolated by design, so coordination belongs in the WebUI. I can file it there (like #4754/#4757) if you want.
- **#51 / #43** — still blocked on WebUI #4754 / #4757 (open).
- **#5** (icon — needs a full-bleed square master), **#37** (Windows restore — needs a Windows smoke), **#9/#10/#11** (enhancements/larger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
