### PR TITLE
chore: bump version to 0.6.7 (fix v0.6.7 release artifact labels)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1706,7 +1706,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermes-webui-desktop"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "arboard",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hermes-webui-desktop"
-version = "0.6.6"
+version = "0.6.7"
 description = "Hermes WebUI Desktop — cross-platform shell for hermes-webui"
 edition = "2021"
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hermes WebUI Desktop",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "identifier": "ai.get-hermes.HermesWebUIDesktop",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
Bumps `tauri.conf.json` + `Cargo.toml` + `Cargo.lock` to **0.6.7**.

The icon-swap release #61 was tagged `v0.6.7` without a version bump, so the build emitted `0.6.6`-named artifacts and the release completeness gate failed (macOS .dmg + Windows .msi/setup didn't land — they collided with v0.6.6's existing same-named assets). All three platform builds themselves succeeded; only `finalize` was red.

After this merges I'll re-point the `v0.6.7` tag at the new commit so artifacts are labeled `0.6.7` and the release finalizes cleanly with the full Win/Mac/Linux asset set.

🤖 Agent-authored release-hygiene fix.