### PR TITLE
CI: harden release finalize — re-sync + verify updater signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,27 @@ jobs:
     # any expected asset. That keeps finalize red until a rerun completes the
     # set, so `gh run rerun --failed` always re-runs it and a release can
     # never sit complete-but-unlabeled (the v0.3.1 first-attempt gap).
+    #
+    # It also re-syncs every latest.json signature from its uploaded .sig
+    # asset and verifies the whole manifest with minisign before re-uploading.
+    # That closes the v0.6.7 class of bug: a re-fired or partially-failed build
+    # can leave latest.json carrying a stale signature from an earlier run
+    # (macOS bundles aren't reproducible — codesign + notarization embed
+    # timestamps), which fails verification on every client. A manifest whose
+    # signatures don't verify keeps finalize red and is never published.
     # RULE: only publish a release whose finalize job is green.
     needs: build
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - name: Rename assets with platform labels and patch latest.json
+      - uses: actions/checkout@v4
+
+      - name: Install minisign (updater-signature verification)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Rename assets, sync + verify latest.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
@@ -163,23 +178,44 @@ jobs:
             fi
           done
 
-          # Patch latest.json URLs to the renamed assets.
+          # Finalize latest.json: patch URLs to the renamed assets, re-sync
+          # every signature from its uploaded .sig asset, then verify the whole
+          # manifest with minisign before re-uploading. Runs whenever a
+          # latest.json exists (NOT gated on a rename) so a re-fire with no
+          # renames still gets its signatures re-synced + verified — that is
+          # exactly the v0.6.7 case. The script exits non-zero (failing this
+          # job) if any artifact/sig is missing or any signature is invalid, so
+          # an unverified manifest is never re-uploaded.
           LJ_ID=$(gh api "repos/$REPO/releases/$RID/assets" --paginate \
             --jq '.[] | select(.name=="latest.json") | .id' | head -1)
-          if [ -n "$LJ_ID" ] && [ -s "$MAP_FILE" ]; then
+          if [ -n "$LJ_ID" ]; then
             gh api "repos/$REPO/releases/assets/$LJ_ID" \
               -H "Accept: application/octet-stream" > latest.json
-            while IFS=$'\t' read -r OLD NEW; do
-              # URL-encode spaces/dots are handled by GitHub; names here are
-              # dot-separated already. Replace both raw and URL-encoded forms.
-              OLD_ENC=$(printf '%s' "$OLD" | sed 's/ /%20/g')
-              NEW_ENC=$(printf '%s' "$NEW" | sed 's/ /%20/g')
-              sed -i "s|$OLD_ENC|$NEW_ENC|g; s|$OLD|$NEW|g" latest.json
-            done < "$MAP_FILE"
-            gh api -X DELETE "repos/$REPO/releases/assets/$LJ_ID" > /dev/null
-            gh release upload "$TAG" latest.json --repo "$REPO"
-            echo "latest.json patched:"
-            grep -o '"url": *"[^"]*"' latest.json || true
+            # 1) URL rename — only when assets were actually renamed this run.
+            if [ -s "$MAP_FILE" ]; then
+              while IFS=$'\t' read -r OLD NEW; do
+                # URL-encode spaces/dots are handled by GitHub; names here are
+                # dot-separated already. Replace both raw and URL-encoded forms.
+                OLD_ENC=$(printf '%s' "$OLD" | sed 's/ /%20/g')
+                NEW_ENC=$(printf '%s' "$NEW" | sed 's/ /%20/g')
+                sed -i "s|$OLD_ENC|$NEW_ENC|g; s|$OLD|$NEW|g" latest.json
+              done < "$MAP_FILE"
+            fi
+            # 2) Download the (renamed) updater artifacts + their .sig assets,
+            #    re-sync latest.json's signatures from them, and verify all.
+            mkdir -p _verify
+            gh release download "$TAG" --repo "$REPO" --dir _verify --clobber \
+              --pattern '*.sig' --pattern '*.app.tar.gz' --pattern '*.msi' \
+              --pattern '*-setup.exe' --pattern '*.AppImage' --pattern '*.deb'
+            PUBKEY=$(jq -r '.plugins.updater.pubkey' src-tauri/tauri.conf.json \
+              | base64 -d | sed -n '2p')
+            python3 scripts/sync_latest_json.py latest.json _verify "$PUBKEY"
+            # 3) Re-upload the verified manifest. --clobber overwrites in one
+            #    step (no window where latest.json is missing); only reached if
+            #    verification passed.
+            gh release upload "$TAG" latest.json --repo "$REPO" --clobber
+            echo "latest.json finalized + signatures verified:"
+            grep -o '"url": *"[^"]*"' latest.json | sort -u || true
           fi
 
           # Completeness gate (real version tags only): fail unless every

--- a/scripts/sync_latest_json.py
+++ b/scripts/sync_latest_json.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Re-sync and verify the updater signatures in a Tauri ``latest.json``.
+
+For each platform entry, the signature is taken from the matching uploaded
+``<artifact>.sig`` asset — the authoritative signature for the *actually
+uploaded* binary — and then verified against that binary with ``minisign``.
+
+This closes the class of bug where a re-fired or partially-failed release
+leaves ``latest.json`` carrying a stale signature from an earlier build. Seen
+on v0.6.7: the macOS binary was rebuilt on the tag re-fire (non-reproducible —
+codesign + notarization embed timestamps) but ``latest.json`` kept the failed
+run's signature, so every macOS client got "signature verification failed".
+Windows/Linux were fine because those builds are reproducible (identical bytes
+across runs → the old signature still matched).
+
+Run by the release workflow's ``finalize`` job as a hard gate, and usable by
+hand to repair a botched release (no signing key required — it only copies a
+signature the build already produced).
+
+Usage:
+    sync_latest_json.py <latest.json> <assets_dir> <minisign_pubkey> [--verify-only]
+
+``<assets_dir>`` must contain, for every platform URL's basename ``B`` found in
+``latest.json``, both ``B`` (the artifact) and ``B.sig`` (its base64-wrapped
+minisign signature, exactly as tauri-action uploads it).
+
+``<minisign_pubkey>`` is the bare key line (``RW...``) — i.e. the second line of
+the decoded ``plugins.updater.pubkey`` from ``src-tauri/tauri.conf.json``.
+
+Rewrites ``latest.json`` in place with re-synced signatures (unless
+``--verify-only``) and exits non-zero if any artifact or ``.sig`` is missing or
+any signature fails to verify.
+"""
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def verify_one(artifact: Path, signature_b64: str, pubkey: str) -> tuple[bool, str]:
+    """Verify a base64-wrapped minisign signature against ``artifact``.
+
+    ``signature_b64`` is the value stored in latest.json / the ``.sig`` asset:
+    base64 of the raw minisign signature file. minisign handles both the legacy
+    (``Ed``) and prehashed (``ED``) algorithms transparently.
+    """
+    try:
+        raw = base64.b64decode(signature_b64)
+    except Exception as exc:  # noqa: BLE001 - report and fail, never raise
+        return False, f"signature is not valid base64: {exc}"
+    with tempfile.NamedTemporaryFile(suffix=".minisig", delete=False) as tf:
+        tf.write(raw)
+        sig_path = tf.name
+    try:
+        proc = subprocess.run(
+            ["minisign", "-V", "-m", str(artifact), "-P", pubkey, "-x", sig_path],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False, "minisign not found on PATH (install it before verifying)"
+    finally:
+        Path(sig_path).unlink(missing_ok=True)
+    if proc.returncode == 0:
+        return True, "ok"
+    return False, (proc.stdout + proc.stderr).strip() or "minisign reported failure"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Re-sync + verify latest.json updater signatures.")
+    ap.add_argument("latest_json", type=Path, help="path to latest.json")
+    ap.add_argument("assets_dir", type=Path, help="dir holding the artifacts + their .sig files")
+    ap.add_argument("pubkey", help="minisign public key line (RW...)")
+    ap.add_argument("--verify-only", action="store_true", help="do not rewrite; only verify")
+    args = ap.parse_args()
+
+    data = json.loads(args.latest_json.read_text(encoding="utf-8"))
+    platforms = data.get("platforms") or {}
+    if not platforms:
+        print("error: latest.json has no platform entries", file=sys.stderr)
+        return 1
+
+    resynced = 0
+    verified = 0
+    problems: list[str] = []
+
+    for key, entry in platforms.items():
+        base = (entry.get("url") or "").rsplit("/", 1)[-1]
+        if not base:
+            problems.append(f"{key}: entry has no url")
+            continue
+        artifact = args.assets_dir / base
+        sigfile = args.assets_dir / (base + ".sig")
+        if not artifact.is_file():
+            problems.append(f"{key}: missing artifact {base}")
+            continue
+        if not sigfile.is_file():
+            problems.append(f"{key}: missing signature asset {base}.sig")
+            continue
+
+        # The .sig asset is the authoritative signature for this exact binary.
+        authoritative = sigfile.read_text(encoding="utf-8").strip()
+        if not args.verify_only and entry.get("signature") != authoritative:
+            entry["signature"] = authoritative
+            resynced += 1
+            print(f"resynced: {key} <- {base}.sig")
+
+        check_sig = authoritative if not args.verify_only else (entry.get("signature") or "")
+        ok, detail = verify_one(artifact, check_sig, args.pubkey)
+        if ok:
+            verified += 1
+            print(f"verified: {key} ({base})")
+        else:
+            problems.append(f"{key}: signature INVALID for {base} — {detail}")
+
+    if not args.verify_only:
+        args.latest_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+    print(f"\nsummary: {resynced} resynced, {verified}/{len(platforms)} verified")
+    if problems:
+        print("\nPROBLEMS:", file=sys.stderr)
+        for p in problems:
+            print(f"  - {p}", file=sys.stderr)
+        return 1
+    print("all updater signatures present and valid ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The v0.6.7 macOS auto-update broke with **"The update couldn't be installed: signature verification failed."** Root cause (diagnosed + already fixed in-place on the v0.6.7 manifest):

- v0.6.7's first CI build failed on macOS; the tag was **re-fired** and the second build succeeded ~15 min later.
- The re-fire **rebuilt + re-signed** the macOS `.app.tar.gz` (timestamp `1782678597`)… but `latest.json` kept the **first (failed) run's** signature (`1782677906`).
- macOS bundles are not reproducible (codesign + notarization embed timestamps), so the stale signature no longer matched the uploaded binary → every macOS client failed verification.
- Windows/Linux were unaffected because those builds **are** reproducible (identical bytes across runs → the old signature still matched).

The hole: `finalize` patched `latest.json`'s **URLs** but never its **signatures**.

## What this changes

`finalize` now, **whenever a `latest.json` exists** (not gated on a rename — so a no-rename re-fire is covered, which is exactly the v0.6.7 case):

1. **Re-syncs** each platform's signature from its uploaded `.sig` asset — the authoritative signature for the *actually-uploaded* binary.
2. **Verifies** the entire manifest with `minisign` before re-uploading, and **fails the job** (so the release is never published) if any artifact/`.sig` is missing or any signature does not verify. This matches the existing rule: *only publish a release whose finalize job is green.*

New `scripts/sync_latest_json.py` does the resync+verify (or `--verify-only`). It is **reusable by hand** to repair a botched release — **no signing key needed**, it only copies a signature the build already produced (this is literally how the v0.6.7 manifest was repaired).

Also: `actions/checkout` (for the pubkey in `tauri.conf.json` + the script), `apt` minisign, and the manifest re-upload switched to `--clobber` (no window where `latest.json` is briefly missing).

## Testing

Ran the script against the **real v0.6.7 release assets**:

| Case | Result |
|---|---|
| Broken manifest (run-1 macOS sig) | resynced 4 darwin entries, verified 10/10, exit 0 |
| Re-run on fixed manifest | 0 resynced, 10/10 verified (idempotent) |
| `--verify-only` | verifies, no rewrite |
| Corrupted artifact | darwin INVALID, **exit 1** |
| Missing `.sig` | reported missing, **exit 1** |

YAML validated; script `py_compile`s clean.

## Notes

- CI-only change — no app behavior and no version bump, so no CHANGELOG entry.
- The real end-to-end proof runs at the **next release**; the new verify gate now protects that release (and the v0.6.7 manifest was already repaired in place, so updating to 0.6.7 works today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
