### PR TITLE
Linux: fix the large empty gap under the tab strip (content webview placed with physical bounds) (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [v0.6.8] — 2026-06-30
+
+### Fixed
+
+- **Linux: the WebUI no longer renders below a large empty gap under the tab
+  strip** (issue #67). On many Linux setups (VMs, Xvfb, remote/forwarded X, and
+  any display where the X server misreports its physical size) the content
+  webview was
+  pushed hundreds of pixels down the window, leaving a tall black band beneath
+  the 38px tab strip and squashing the app into the lower portion of the window.
+  Root cause: the shell positions each tab's webview as an X11 child window, and
+  wry's WebKitGTK backend re-derives its *own* scale factor for child windows
+  from the X screen's reported DPI (`screen_px × 25.4 ÷ screen_mm ÷ 96`). When
+  that DPI is wrong, the logical `38px` strip offset we passed got multiplied by
+  the bad factor (≈4.5× on the affected display → a ~171px gap). The strip and
+  content webviews are now placed with **physical** coordinates computed from
+  the window's real GTK scale factor, which wry passes through unchanged — so
+  the geometry lands exactly under the tab strip regardless of the X server's
+  DPI, and stays correct on genuine HiDPI displays. macOS and Windows are
+  unaffected (their webview backends already use the window's real scale).
+
 ## [v0.6.6] — 2026-06-24
 
 A batch of bug fixes and features: background-tab notifications, a Mac-native

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -16,10 +16,50 @@ use std::sync::atomic::Ordering;
 use tauri::webview::{Color, Cookie, WebviewBuilder};
 use tauri::window::WindowBuilder;
 use tauri::{
-    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, Webview, WebviewUrl, Window, Wry,
+    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, PhysicalPosition, PhysicalSize,
+    Position, Size, Webview, WebviewUrl, Window, Wry,
 };
 
 pub const STRIP_HEIGHT: f64 = 38.0;
+
+/// Convert a logical child-webview position to the unit the platform's wry
+/// backend wants for `add_child` / `set_position`.
+///
+/// macOS (WKWebView) and Windows (WebView2) place child webviews using the
+/// window's OWN scale factor, so logical coordinates land correctly. WebKitGTK
+/// (Linux) is the exception: wry creates the child as an X11 sub-window and
+/// re-derives its OWN scale factor from the X screen's reported physical size
+/// (`scale_factor_from_x11` = screen_px * 25.4 / screen_mm / 96). On VMs, Xvfb,
+/// remote/forwarded X and many real setups that value is bogus (X reports a
+/// nonsense mm size), so wry multiplies our logical 38px strip offset by a
+/// wrong factor and the content webview is shoved hundreds of pixels down —
+/// the big empty gap under the tab strip, never caught by the headless smoke
+/// test (which runs against a fake X screen). Passing PHYSICAL coordinates
+/// (computed with tao's real GTK scale factor) makes wry's internal
+/// `to_physical()` an identity cast, so the geometry lands exactly where
+/// intended regardless of the X server's DPI lie — and stays correct under
+/// genuine HiDPI (scale 2).
+fn child_position(x: f64, y: f64, scale: f64) -> Position {
+    if cfg!(target_os = "linux") {
+        PhysicalPosition::new((x * scale).round() as i32, (y * scale).round() as i32).into()
+    } else {
+        LogicalPosition::new(x, y).into()
+    }
+}
+
+/// Companion to [`child_position`] for sizes — see that doc for why Linux needs
+/// physical units while macOS/Windows take logical.
+fn child_size(w: f64, h: f64, scale: f64) -> Size {
+    if cfg!(target_os = "linux") {
+        PhysicalSize::new(
+            (w * scale).round().max(0.0) as u32,
+            (h * scale).round().max(0.0) as u32,
+        )
+        .into()
+    } else {
+        LogicalSize::new(w, h).into()
+    }
+}
 
 /// Strip mode is the tab implementation everywhere except macOS.
 pub fn enabled() -> bool {
@@ -47,15 +87,15 @@ fn find_webview(win: &Window<Wry>, label: &str) -> Option<Webview<Wry>> {
     win.webviews().into_iter().find(|w| w.label() == label)
 }
 
-fn content_bounds(win: &Window<Wry>, top: f64) -> (LogicalPosition<f64>, LogicalSize<f64>) {
+fn content_bounds(win: &Window<Wry>, top: f64) -> (Position, Size) {
     let scale = win.scale_factor().unwrap_or(1.0);
     let size = win
         .inner_size()
         .map(|s| s.to_logical::<f64>(scale))
         .unwrap_or(LogicalSize::new(1280.0, 830.0));
     (
-        LogicalPosition::new(0.0, top),
-        LogicalSize::new(size.width, (size.height - top).max(0.0)),
+        child_position(0.0, top, scale),
+        child_size(size.width, (size.height - top).max(0.0), scale),
     )
 }
 
@@ -244,8 +284,8 @@ fn build_strip_window(
         .unwrap_or(LogicalSize::new(1280.0, 830.0));
     if let Err(e) = win.add_child(
         swb,
-        LogicalPosition::new(0.0, 0.0),
-        LogicalSize::new(logical.width, STRIP_HEIGHT),
+        child_position(0.0, 0.0, scale),
+        child_size(logical.width, STRIP_HEIGHT, scale),
     ) {
         log::error!("strip: strip webview failed: {e}");
     }


### PR DESCRIPTION
Closes #67.

## The bug

On Linux the WebUI renders **below a large empty/black band** under the 38px tab strip, squashing the app into the lower part of the window (reported via Discord screenshot on a Linux desktop build). 

## Root cause

The Win/Linux strip (`strip.rs`) positions each tab's content webview as an X11 **child window** at `y = 38px`, passing **logical** coordinates. wry's WebKitGTK backend re-derives its **own** scale factor for child windows from the X screen's reported physical size:

```
scale_factor_from_x11 = screen_px × 25.4 ÷ screen_mm ÷ 96
```

On VMs / Xvfb / remote-forwarded X / any display that misreports its mm size, that value is bogus. wry then computes `Logical(38).to_physical(~4.5)` ≈ **171px**, pushing the content webview ~171px down — the gap. macOS (WKWebView) and Windows (WebView2) use the window's real scale, so they're unaffected.

I confirmed the mechanism end-to-end against the pinned dep sources:
- `wry 0.55.1` `webkitgtk/mod.rs`: `create_container_x11_window` / `set_bounds` apply `scale_factor_from_x11`; `Position::Physical` is an **identity cast**, `Position::Logical` is a **multiply**.
- `tauri-runtime-wry 2.11.2` `RectWrapper` + `with_bounds`: the `Position`/`Size` enum variant is preserved straight through to wry (no logical normalization).
- `tao 0.35.3`: Linux `scale_factor()` is the **GTK integer** widget scale (the correct render scale), not the bogus X11 float.

And reproduced the arithmetic numerically against the `dpi` crate: logical-38 → **171px** (matches the observed gap), physical-38 → **38px** (fixed), HiDPI scale-2 → 76px (correct).

## The fix

Place the strip + content child webviews with **physical** coordinates (computed from the window's real GTK scale factor) on Linux. wry passes `Physical` bounds through with an identity cast, so geometry lands exactly under the strip regardless of the X server's DPI, and stays correct under genuine HiDPI (scale 2). macOS/Windows keep logical bounds. Centralized in two small helpers (`child_position` / `child_size`) used by `content_bounds` and the strip-webview placement.

## Why CI didn't catch it

`linux-smoke` runs headless under Xvfb and only asserts "connected" + uploads a screenshot for human review — the gap is visible in that artifact (content text starts at ~y170) but wasn't asserted on. This PR's CI run will rebuild and produce a fresh smoke screenshot for visual confirmation that the page now sits directly under the strip.

## Testing

- Verified the fix arithmetic against the real `dpi` crate (logical→171 vs physical→38, plus HiDPI scale-2→76).
- `cargo fmt --check` clean.
- Full Linux compile + visual confirmation rely on CI here (the GTK/WebKit dev libs aren't available in my local env).

> Version bump (3 files) intentionally left to the releaser per the repo's release convention.