### PR TITLE
Probes: trust OS-installed CAs — Test Connection works behind enterprise/internal PKI (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.6.9]
+
+### Fixed
+
+- **"Test Connection" (and all connection probes) now trust enterprise and
+  internal CAs installed in the OS trust store.** The Rust-side probes
+  verified TLS against the bundled Mozilla root store only, so a server
+  behind a corporate PKI or an internal CA (e.g. Caddy Local Authority) that
+  the OS trusts — and that the webview itself happily loads — reported
+  "✗ Unreachable". Probes now verify against the union of the bundled roots
+  and the OS trust store: strictly additive, so every certificate that
+  verified before still does, and certificate verification is never skipped
+  or weakened. (#60, reported by ycj; supersedes the declined
+  disable-verification approach from PR #59.)
+
 ## [v0.6.8] — 2026-06-30
 
 ### Fixed

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1717,6 +1717,8 @@ dependencies = [
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
  "regex",
+ "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_json",
  "tauri",
@@ -1732,6 +1734,7 @@ dependencies = [
  "tauri-plugin-updater",
  "ureq",
  "url",
+ "webpki-roots 0.26.11",
  "x11-dl",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"
 ureq = "2"
+# Probe TLS trust (issue #60): health.rs unions the webpki baseline with the
+# OS trust store so enterprise/internal CAs verify like they do in the system
+# webview. Versions/features track what ureq 2.x already pulls in.
+rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
+webpki-roots = "0.26"
+rustls-native-certs = "0.8"
 arboard = "3"
 image = { version = "0.25", default-features = false, features = ["png"] }
 base64 = "0.22"

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -2,14 +2,62 @@
 //! GET (never HEAD — servers may 405/501 it), and ANY HTTP response —
 //! including 4xx/5xx — counts as reachable; only transport errors fail.
 
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
-pub fn http_reachable(url: &str, timeout: Duration) -> bool {
-    let agent = ureq::AgentBuilder::new()
+/// Probe TLS roots: the bundled Mozilla store UNIONed with the OS trust
+/// store. ureq's default is webpki-roots alone, which rejects
+/// enterprise/internal CAs the user's OS trusts — the system webview
+/// (WKWebView/WebView2/WebKitGTK) verifies against the OS store, so the page
+/// loads fine while Test Connection said "Unreachable" (issue #60). The union
+/// is deliberately additive-only: everything that verified before still
+/// verifies, and a broken/empty OS store can never make things worse than
+/// the webpki baseline (ureq's own `native-certs` feature REPLACES the
+/// baseline and fails open to an empty store — not acceptable here).
+/// Certificate verification itself is never skipped (the closed PR #59
+/// approach).
+fn probe_roots() -> rustls::RootCertStore {
+    let mut roots = rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let baseline = roots.roots.len();
+    let native = rustls_native_certs::load_native_certs();
+    for e in &native.errors {
+        log::warn!("probe tls: OS trust store: {e}");
+    }
+    let (added, unparsable) = roots.add_parsable_certificates(native.certs);
+    log::info!("probe tls: {baseline} webpki roots + {added} OS roots ({unparsable} unparsable)");
+    roots
+}
+
+fn probe_tls_config() -> Arc<rustls::ClientConfig> {
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    CONFIG
+        .get_or_init(|| {
+            // Mirror ureq's own construction (rtls.rs): explicit ring provider
+            // so an ambiguous process-wide default can never panic the build.
+            let config = rustls::ClientConfig::builder_with_provider(
+                rustls::crypto::ring::default_provider().into(),
+            )
+            .with_protocol_versions(&[&rustls::version::TLS12, &rustls::version::TLS13])
+            .expect("ring provider supports TLS 1.2 + 1.3")
+            .with_root_certificates(probe_roots())
+            .with_no_client_auth();
+            Arc::new(config)
+        })
+        .clone()
+}
+
+fn agent(timeout: Duration) -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .tls_config(probe_tls_config())
         .timeout_connect(timeout)
         .timeout(timeout)
-        .build();
-    match agent.get(url).call() {
+        .build()
+}
+
+pub fn http_reachable(url: &str, timeout: Duration) -> bool {
+    match agent(timeout).get(url).call() {
         Ok(_) => true,
         // An HTTP status error still means the round-trip completed.
         Err(ureq::Error::Status(_, _)) => true,
@@ -30,11 +78,7 @@ pub fn http_reachable(url: &str, timeout: Duration) -> bool {
 /// upstream-unavailable gateway codes are rejected. Transport errors = not
 /// ready, as before.
 pub fn http_ready(url: &str, timeout: Duration) -> bool {
-    let agent = ureq::AgentBuilder::new()
-        .timeout_connect(timeout)
-        .timeout(timeout)
-        .build();
-    match agent.get(url).call() {
+    match agent(timeout).get(url).call() {
         Ok(_) => true,
         Err(ureq::Error::Status(code, _)) => ready_from_status(code),
         Err(_) => false,
@@ -89,5 +133,36 @@ mod tests {
     fn health_url_joins_with_one_slash() {
         assert_eq!(health_url("http://h:8787"), "http://h:8787/health");
         assert_eq!(health_url("http://h:8787/"), "http://h:8787/health");
+    }
+
+    #[test]
+    fn probe_roots_never_shrink_below_webpki_baseline() {
+        // The union property behind the issue-#60 fix: OS roots are ADDED to
+        // the webpki baseline, never substituted for it. A broken/empty OS
+        // store must degrade to exactly the old behavior, not to no roots
+        // (which is ureq's own `native-certs` failure mode).
+        let roots = probe_roots();
+        assert!(
+            roots.roots.len() >= webpki_roots::TLS_SERVER_ROOTS.len(),
+            "probe roots ({}) fell below the webpki baseline ({})",
+            roots.roots.len(),
+            webpki_roots::TLS_SERVER_ROOTS.len()
+        );
+    }
+
+    #[test]
+    fn probe_tls_config_builds() {
+        // Guards the provider/protocol construction (would panic here, not in
+        // a user's Test Connection click).
+        let _ = probe_tls_config();
+    }
+
+    #[test]
+    #[ignore = "network: manual sanity check that the union store verifies a live public host"]
+    fn probe_live_https_roundtrip() {
+        assert!(http_reachable(
+            "https://github.com",
+            Duration::from_secs(10)
+        ));
     }
 }


### PR DESCRIPTION
## Symptom (#60, reported by ycj)

"Test Connection" reports **✗ Unreachable** for servers that load fine in any browser — whenever the server's TLS certificate chains to an enterprise/internal CA (corporate PKI, Caddy Local Authority, self-signed CA imported into the OS trust store).

## Root cause

The Rust-side probes (`health::http_reachable` / `http_ready` — used by Test Connection, the connect preflight, tunnel readiness, and health polling) build default `ureq` agents, which verify TLS against the **bundled Mozilla root store only** (`webpki-roots`). The system webview (WKWebView / WebView2 / WebKitGTK) verifies against the **OS trust store** — so the page itself loads while our probes call the same server unreachable. Enterprise CAs live exactly in that gap.

## Why not PR #59's approach

#59 disabled certificate verification entirely (`curl -k` equivalent) — that silently accepts *any* certificate for every probe, including MITM'd ones, and was rightly closed.

## Fix

Probes now verify against the **union** of the bundled Mozilla roots and the OS trust store (`rustls-native-certs`), built once and cached:

- **Strictly additive** — every certificate that verified before still verifies; a broken/empty OS store degrades to exactly the old behavior. (Deliberately NOT ureq's own `native-certs` feature, which *substitutes* the store and fails open to an empty one — all-HTTPS-fails — on load errors.)
- **Verification is never skipped or weakened.**
- Provider/protocol construction mirrors ureq's own `rtls.rs` (explicit *ring* provider, TLS 1.2+1.3) so no process-default-provider ambiguity.
- Startup log line reports webpki + OS root counts for field debugging.

## Verification

- New unit tests: union-property guard (roots can never fall below the webpki baseline) + config-build guard; plus an `#[ignore]`d live-network round-trip (passes locally against a public host through the new store).
- `cargo fmt` / `clippy --all-targets -- -D warnings` / `cargo test` (20 passed) clean; `cargo xwin check` clean (Windows uses the same pure-Rust path; `rustls-native-certs` reads SChannel/Keychain/ca-certificates per platform).
- Versions pinned to what ureq 2.x already pulls in — no new major dependency trees.

Definitive field verification needs a machine with an enterprise CA in the OS store — @ycj, if you're able to test a build of this branch against your Caddy setup, that would close the loop.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)