### PR TITLE
v0.7.0 issue sweep: Wayland gap, mac tab-state indicators, notification dedupe, stale spinner, restore probe, refresh-all + QoL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,65 @@
 # Changelog
 
-## [v0.6.9] — 2026-07-11
+## [v0.7.0] — 2026-07-18
+
+An issue-sweep release: nine tracker items land at once — Wayland layout,
+macOS per-tab state indicators, cross-tab notification dedupe, stale-spinner
+and restored-session fixes, refresh-all, and quality-of-life items.
+
+### Added
+
+- **macOS: native tabs now show per-tab state** — "●" prefixed to the tab
+  title when a session is waiting on you (approval/clarify), "⟳" while it's
+  working (issues #64/#65). The signals existed (the page reports both) but
+  macOS discarded them; they now adorn the native tab title the same way the
+  profile-name prefix does, so a backgrounded tab's state is visible at a
+  glance. Attention outranks working when both apply.
+- **Refresh All Tabs** (issue #76): one action — in the ⋮ menu, the macOS
+  View menu, or Ctrl/Cmd+Shift+R — reloads every tab in every window, so a
+  WebUI update no longer means clicking the "must hard refresh" banner in
+  each tab individually.
+- **Click-to-copy version** (issue #75): the version row in the ⋮ menu (and
+  a new "Copy Version" item in the macOS app menu) copies a paste-ready
+  identifier for bug reports, confirmed with a notification.
+- **Linux safe-render escape hatch** (issue #78): launching with
+  `HERMES_DESKTOP_SAFE_RENDER=1` disables WebKitGTK's DMABUF renderer and
+  compositing mode before any webview initializes — the recovery path for
+  GPU/driver combos where EGL fails and the window comes up blank (e.g.
+  "Could not create default EGL display: EGL_BAD_PARAMETER" on Fedora).
+  Explicitly-set `WEBKIT_*` variables always win.
+
+### Fixed
+
+- **Wayland: huge empty space above the WebUI** (issue #80). The v0.6.8 fix
+  for the X11 gap (#67) passes physical child-webview coordinates to defeat
+  wry's bogus X11 DPI derivation — but it applied on ALL Linux, and on native
+  Wayland (where wry's scale is sane) it over-corrects into a top gap. The
+  compensation now applies only when GDK actually runs its X11 backend
+  (including XWayland, which needs it); native Wayland gets plain logical
+  coordinates.
+- **Duplicate notifications across tabs, and notification floods** (issues
+  #51/#81). Every tab observes the same server events, so N open tabs meant
+  N identical OS notifications — and a page re-firing for a still-pending
+  approval could pile up notifications indefinitely (reported on Linux/
+  Wayland as "approval kept appearing until the app crashed"). All tabs
+  funnel through one native handler, which now suppresses identical
+  notifications within a 30-second window: many tabs produce one
+  notification, and a persistent repeater surfaces at most once per window
+  as a gentle reminder instead of a flood.
+- **Tab "working" spinner no longer goes stale on background tabs** (issue
+  #74). Hidden webviews throttle their timers, so the in-page busy reporter
+  could go quiet and leave a finished session spinning until you clicked the
+  tab. The shell now re-polls every tab's busy state on its own 4-second
+  loop — an eval runs regardless of timer throttling — so the spinner clears
+  within seconds of the session finishing, focused or not.
+- **Restored session tabs showing "Session not available in web UI." at
+  launch** (issue #37, third and hopefully final round). The v0.6.1 retry
+  only caught the variant where the WebUI bounces the tab back to the root
+  URL; the reported symptom shows the message in place at the deep URL. The
+  shell now also probes the restored tab's page once (~5s after creation)
+  and reloads it in place if the marker is present — the programmatic
+  equivalent of the switch-away-and-back that always fixed it. Healthy tabs
+  match nothing and pay nothing.
 
 ### Fixed
 

--- a/src-tauri/src/bridge.rs
+++ b/src-tauri/src/bridge.rs
@@ -412,6 +412,7 @@ const SHORTCUT_FORWARDER: &str = r##"
     var send = function (v) { e.preventDefault(); e.stopPropagation(); EMIT('shortcut', v); };
     if (k === 'tab') { send(e.shiftKey ? 'prev-tab' : 'next-tab'); return; }
     if (k === 'b' && e.shiftKey) { send('toggle-bar'); return; }
+    if (k === 'r' && e.shiftKey) { send('reload-all'); return; }
     if (e.shiftKey) return;
     if (k === 't') send('new-tab');
     else if (k === 'n') send('new-window');
@@ -559,6 +560,12 @@ const BUSY_REPORTER: &str = r##"
     else report();
     setInterval(report, 700);
     window.addEventListener('focus', report);
+    // Native re-poll hook (issue #74): hidden webviews throttle/suspend timers,
+    // so a session finishing in a background tab may never tick the interval —
+    // the spinner goes stale until focus. The shell evals this on its own 4s
+    // loop; an eval executes even when timers are throttled, and it re-reads
+    // the live S.busy at that moment.
+    window.__hermesReportBusy = report;
   })();
 "##;
 
@@ -614,11 +621,13 @@ pub fn init_script(label: &str, pre_paint_hex: &str, is_ssh: bool) -> String {
     }
     if cfg!(not(target_os = "macos")) {
         parts.push(SHORTCUT_FORWARDER);
-        // Profile dot + working glyph are strip-only (Windows/Linux); macOS
-        // native tabs have no strip, so skip these reporters there (#31, #46).
+        // Profile dot is strip-only (Windows/Linux); macOS gets its profile
+        // indicator from MACOS_PROFILE_REPORTER above (#31, #44).
         parts.push(PROFILE_REPORTER);
-        parts.push(BUSY_REPORTER);
     }
+    // Busy state feeds the strip spinner on Win/Linux (#46) AND the native
+    // tab-title "⟳" adornment on macOS (#65) — inject everywhere.
+    parts.push(BUSY_REPORTER);
     parts.push(THEME_BRIDGE);
     parts.push(ROUTE_REPORTER);
     parts.push(WINDOW_OPEN);
@@ -688,11 +697,15 @@ pub fn install(app: &AppHandle) {
                     crate::strip::set_tab_dot_profile(&handle, &label, &name);
                 }
             }
-            // Tab busy/streaming state for the per-tab "working" glyph (#46).
+            // Tab busy/streaming state: the per-tab "working" glyph on the
+            // Win/Linux strip (#46), and the "⟳" native-title adornment on
+            // macOS content windows (#65).
             "busy" => {
+                let busy = payload["value"].as_bool().unwrap_or(false);
                 if crate::strip::enabled() && label.starts_with("tab-") {
-                    let busy = payload["value"].as_bool().unwrap_or(false);
                     crate::strip::set_tab_busy(&handle, &label, busy);
+                } else if cfg!(target_os = "macos") && label.starts_with("main-") {
+                    windows::set_window_indicator(&handle, &label, Some(busy), None);
                 }
             }
             // Active-profile NAME for the macOS native tab title (issue #44).
@@ -709,12 +722,23 @@ pub fn install(app: &AppHandle) {
                     let body = payload["value"]["body"]
                         .as_str()
                         .unwrap_or("Your response is ready");
-                    let _ = handle
-                        .notification()
-                        .builder()
-                        .title(title)
-                        .body(body)
-                        .show();
+                    // Cross-tab dedupe (issues #51/#81): every tab carries the
+                    // notification shim independently, so N tabs observing the
+                    // same server event (approval pending, response ready) each
+                    // emit the same notify — and a re-firing page can loop.
+                    // This is the single choke point all tabs funnel through;
+                    // suppress identical title+body within a fixed window. A
+                    // still-pending approval re-notifies at most once per
+                    // window (gentle reminder) instead of flooding (#81), and
+                    // app re-open with many tabs shows ONE notification (#51).
+                    if notify_fresh(title, body) {
+                        let _ = handle
+                            .notification()
+                            .builder()
+                            .title(title)
+                            .body(body)
+                            .show();
+                    }
                 }
             }
             "open-external" => {
@@ -778,6 +802,11 @@ pub fn install(app: &AppHandle) {
                         }
                         "next-tab" => crate::strip::cycle_tab(&handle, &label, true),
                         "prev-tab" => crate::strip::cycle_tab(&handle, &label, false),
+                        // Reload every tab in every window (issue #76): one
+                        // action to clear the per-tab "must hard refresh"
+                        // banners after a WebUI update (also the ⋮/View menu
+                        // "Refresh All Tabs").
+                        "reload-all" => windows::eval_all_content(&handle, "location.reload();"),
                         "toggle-bar" => {
                             if crate::strip::enabled() && label.starts_with("tab-") {
                                 let app = handle.clone();
@@ -892,4 +921,84 @@ fn handle_theme_report(app: &AppHandle, css: &str) {
     );
     let state = app.state::<AppState>();
     let _ = state; // theme cache persisted above; nothing else to track
+}
+
+/// Cross-tab notification dedupe (issues #51/#81). Every tab carries the
+/// notification shim independently, so N tabs observing the same server-side
+/// event each emit an identical notify — and a page that re-fires for a
+/// still-pending approval can loop. All tabs funnel through the single
+/// `"notify"` bridge arm, so one fixed-window cache there collapses both.
+/// FIXED window (timestamps aren't refreshed on suppressed hits): a pending
+/// approval still re-notifies once per window as a gentle reminder, instead
+/// of never again — and instead of a flood.
+fn notify_fresh(title: &str, body: &str) -> bool {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Instant;
+    static SEEN: OnceLock<Mutex<HashMap<String, Instant>>> = OnceLock::new();
+    let mut seen = SEEN
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap();
+    dedupe_decide(&mut seen, format!("{title}\u{1}{body}"), Instant::now())
+}
+
+/// Pure decision for [`notify_fresh`]: prune expired entries, then show only
+/// if the key isn't present. Insert-on-show only — suppressed repeats do NOT
+/// slide the window, so a persistent repeater surfaces once per WINDOW.
+const NOTIFY_DEDUPE_WINDOW: std::time::Duration = std::time::Duration::from_secs(30);
+fn dedupe_decide(
+    seen: &mut std::collections::HashMap<String, std::time::Instant>,
+    key: String,
+    now: std::time::Instant,
+) -> bool {
+    seen.retain(|_, t| now.duration_since(*t) < NOTIFY_DEDUPE_WINDOW);
+    if seen.contains_key(&key) {
+        return false;
+    }
+    seen.insert(key, now);
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{dedupe_decide, NOTIFY_DEDUPE_WINDOW};
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn duplicate_notifications_suppressed_within_window() {
+        let mut seen = HashMap::new();
+        let t0 = Instant::now();
+        assert!(dedupe_decide(&mut seen, "a\u{1}b".into(), t0));
+        // Same title+body from another tab moments later (#51) → suppressed.
+        assert!(!dedupe_decide(
+            &mut seen,
+            "a\u{1}b".into(),
+            t0 + Duration::from_secs(2)
+        ));
+        // A flood of identical re-fires (#81) stays suppressed inside the window…
+        assert!(!dedupe_decide(
+            &mut seen,
+            "a\u{1}b".into(),
+            t0 + Duration::from_secs(15)
+        ));
+        // …but a still-pending approval re-notifies once the window lapses
+        // (fixed window: the suppressed hits above must not have slid it).
+        assert!(dedupe_decide(
+            &mut seen,
+            "a\u{1}b".into(),
+            t0 + NOTIFY_DEDUPE_WINDOW + Duration::from_secs(1)
+        ));
+    }
+
+    #[test]
+    fn distinct_notifications_pass_through() {
+        let mut seen = HashMap::new();
+        let t0 = Instant::now();
+        assert!(dedupe_decide(&mut seen, "a\u{1}b".into(), t0));
+        // Different body (another session finishing) is NOT collapsed.
+        assert!(dedupe_decide(&mut seen, "a\u{1}c".into(), t0));
+        assert!(dedupe_decide(&mut seen, "x\u{1}b".into(), t0));
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -230,6 +230,24 @@ fn main() {
         unsafe { (xlib.XInitThreads)() };
     }
 
+    // Linux safe-render escape hatch (issue #78): on some GPU/driver combos
+    // (NVIDIA proprietary, some VMs, Fedora+EGL mismatches) WebKitGTK's DMABUF
+    // renderer fails hard — "Could not create default EGL display:
+    // EGL_BAD_PARAMETER" and a blank window, app unusable. Setting
+    // HERMES_DESKTOP_SAFE_RENDER=1 flips WebKitGTK to its safe paths BEFORE
+    // any webview initializes. Explicit user-set WEBKIT_* values always win.
+    #[cfg(target_os = "linux")]
+    if std::env::var("HERMES_DESKTOP_SAFE_RENDER").is_ok_and(|v| v == "1") {
+        for (k, v) in [
+            ("WEBKIT_DISABLE_DMABUF_RENDERER", "1"),
+            ("WEBKIT_DISABLE_COMPOSITING_MODE", "1"),
+        ] {
+            if std::env::var(k).is_err() {
+                std::env::set_var(k, v);
+            }
+        }
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             // Second launch (e.g. double-opening the .app/.exe): focus the
@@ -406,6 +424,16 @@ fn main() {
                     if strip::enabled() {
                         strip::recapture_profiles(&sess_handle);
                     }
+                    // Busy re-poll (issue #74): hidden webviews throttle their
+                    // timers, so BUSY_REPORTER's 700ms interval can go quiet in
+                    // a background tab and leave the spinner stale after the
+                    // session finishes. An eval executes regardless of timer
+                    // throttling and re-reads the live S.busy; the reporter's
+                    // debounce means this emits only on an actual change.
+                    windows::eval_all_content(
+                        &sess_handle,
+                        "window.__hermesReportBusy && window.__hermesReportBusy();",
+                    );
                 });
             }
             // Chrome poller — the Tauri stand-in for the Swift app's
@@ -440,6 +468,27 @@ fn main() {
             "new_tab" => conn::open_new_session(app, true),
             "paste" => paste::paste_into_focused(app),
             "reload" => windows::active_content_eval(app, "location.reload();"),
+            // Reload EVERY tab in every window (issue #76): one action to
+            // clear the per-tab "must hard refresh" banners after a WebUI
+            // update, instead of clicking through each tab.
+            "reload_all" => windows::eval_all_content(app, "location.reload();"),
+            // Click-to-copy the version from the ⋮/app menu (issue #75) —
+            // exact paste-ready string for bug reports, confirmed by a
+            // notification (it's a direct user action, so always confirm).
+            "copy_version" => {
+                let v = format!(
+                    "Hermes WebUI Desktop v{} ({})",
+                    app.package_info().version,
+                    std::env::consts::OS
+                );
+                let copied = arboard::Clipboard::new()
+                    .and_then(|mut c| c.set_text(v.clone()))
+                    .is_ok();
+                if copied {
+                    use tauri_plugin_notification::NotificationExt;
+                    let _ = app.notification().builder().title("Copied").body(v).show();
+                }
+            }
             "quit" => app.exit(0),
             "check_updates" => updater::spawn_check(app, true),
             "reveal_logs" => {

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -10,6 +10,10 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .separator()
         .item(&MenuItemBuilder::with_id("check_updates", "Check for Updates…").build(app)?)
         .item(&MenuItemBuilder::with_id("whats_new", "What's New").build(app)?)
+        .item(
+            // Paste-ready version string for bug reports (issue #75).
+            &MenuItemBuilder::with_id("copy_version", "Copy Version").build(app)?,
+        )
         .item(&MenuItemBuilder::with_id("reveal_logs", "Reveal Log File").build(app)?)
         .separator()
         .item(
@@ -75,6 +79,12 @@ pub fn build(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
         .item(
             &MenuItemBuilder::with_id("reload", "Reload")
                 .accelerator("CmdOrCtrl+R")
+                .build(app)?,
+        )
+        .item(
+            // Reload every tab in every window (issue #76).
+            &MenuItemBuilder::with_id("reload_all", "Refresh All Tabs")
+                .accelerator("CmdOrCtrl+Shift+R")
                 .build(app)?,
         )
         .separator()
@@ -156,6 +166,12 @@ pub fn build_strip_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     items.push(Box::new(PredefinedMenuItem::separator(app)?));
     items.push(Box::new(item("reload", "Reload\tCtrl+R")?));
     items.push(Box::new(item("find", "Find in Page…\tCtrl+F")?));
+    // One action to reload every tab in every window (issue #76) — clears the
+    // per-tab "must hard refresh" banners after a WebUI update.
+    items.push(Box::new(item(
+        "reload_all",
+        "Refresh All Tabs\tCtrl+Shift+R",
+    )?));
     items.push(Box::new(PredefinedMenuItem::separator(app)?));
     items.push(Box::new(item("zoom_in", "Zoom In\tCtrl+=")?));
     items.push(Box::new(item("zoom_out", "Zoom Out\tCtrl+-")?));
@@ -164,11 +180,13 @@ pub fn build_strip_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     items.push(Box::new(item("preferences", "Preferences…\tCtrl+,")?));
     items.push(Box::new(item("open_browser", "Open in Browser")?));
     items.push(Box::new(PredefinedMenuItem::separator(app)?));
-    items.push(Box::new(
-        MenuItemBuilder::with_id("about_version", format!("Hermes WebUI Desktop v{version}"))
-            .enabled(false)
-            .build(app)?,
-    ));
+    // Click-to-copy (issue #75): the version row is a live item — clicking it
+    // copies a paste-ready identifier for bug reports (confirmed by a
+    // notification via the copy_version handler).
+    items.push(Box::new(item(
+        "copy_version",
+        &format!("Hermes WebUI Desktop v{version} — click to copy"),
+    )?));
     items.push(Box::new(item("whats_new", "What's New")?));
     items.push(Box::new(item("check_updates", "Check for Updates…")?));
     items.push(Box::new(item("reveal_logs", "Reveal Log File")?));

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -104,6 +104,13 @@ pub struct AppState {
     /// prefix. Display-only; the cookie-value `window_profiles` above remains
     /// the source for restore re-seeding.
     pub window_profile_names: Mutex<HashMap<String, String>>,
+    /// macOS only: content-window label -> (busy, attention) for the native
+    /// tab-title adornment (issues #64/#65) — "●" when the session waits on
+    /// you, "⟳" while it works. Win/Linux keep these per-TabEntry (the strip
+    /// dot and spinner) instead. busy arrives via BUSY_REPORTER bridge events
+    /// (now injected on macOS too); attention via the leading ● marker on the
+    /// reported document.title, which the mac branch previously discarded.
+    pub window_indicators: Mutex<HashMap<String, (bool, bool)>>,
     /// macOS only: set once per launch after the first connect to fire the
     /// one-time "tabs exist" discoverability hint at most once per run (issue
     /// #42); the persisted `tabsHintShown` pref is the across-launch gate.
@@ -166,6 +173,7 @@ impl AppState {
             strip: Mutex::new(HashMap::new()),
             window_profiles: Mutex::new(HashMap::new()),
             window_profile_names: Mutex::new(HashMap::new()),
+            window_indicators: Mutex::new(HashMap::new()),
             tabs_hinted: AtomicBool::new(false),
             navigated: Mutex::new(HashSet::new()),
             session_restored: AtomicBool::new(false),

--- a/src-tauri/src/strip.rs
+++ b/src-tauri/src/strip.rs
@@ -40,7 +40,7 @@ pub const STRIP_HEIGHT: f64 = 38.0;
 /// intended regardless of the X server's DPI lie — and stays correct under
 /// genuine HiDPI (scale 2).
 fn child_position(x: f64, y: f64, scale: f64) -> Position {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && linux_backend_is_x11() {
         PhysicalPosition::new((x * scale).round() as i32, (y * scale).round() as i32).into()
     } else {
         LogicalPosition::new(x, y).into()
@@ -50,7 +50,7 @@ fn child_position(x: f64, y: f64, scale: f64) -> Position {
 /// Companion to [`child_position`] for sizes — see that doc for why Linux needs
 /// physical units while macOS/Windows take logical.
 fn child_size(w: f64, h: f64, scale: f64) -> Size {
-    if cfg!(target_os = "linux") {
+    if cfg!(target_os = "linux") && linux_backend_is_x11() {
         PhysicalSize::new(
             (w * scale).round().max(0.0) as u32,
             (h * scale).round().max(0.0) as u32,
@@ -59,6 +59,42 @@ fn child_size(w: f64, h: f64, scale: f64) -> Size {
     } else {
         LogicalSize::new(w, h).into()
     }
+}
+
+/// Whether GDK is running its X11 backend (vs native Wayland). The #67/#68
+/// bogus-DPI derivation this file compensates for lives ONLY in wry's X11
+/// path (`scale_factor_from_x11`); on native Wayland wry's scale is sane, so
+/// applying the physical-coordinate compensation there over-corrects and
+/// shoves the content down — the issue #80 top gap. GDK picks Wayland when
+/// `WAYLAND_DISPLAY` is set unless `GDK_BACKEND` overrides; XWayland
+/// (`GDK_BACKEND=x11` under a Wayland session) goes through the X11 path and
+/// DOES need the compensation.
+fn linux_backend_is_x11() -> bool {
+    use std::sync::OnceLock;
+    static IS_X11: OnceLock<bool> = OnceLock::new();
+    *IS_X11.get_or_init(|| {
+        x11_from_env(
+            std::env::var("GDK_BACKEND").ok().as_deref(),
+            std::env::var("WAYLAND_DISPLAY").is_ok(),
+        )
+    })
+}
+
+/// Pure decision for [`linux_backend_is_x11`], mirroring GDK's backend choice.
+/// `GDK_BACKEND` is an ordered preference list ("x11,wayland") — the first
+/// recognized backend wins (XWayland makes x11 startable on Wayland desktops,
+/// so first-listed is what actually runs in practice).
+fn x11_from_env(gdk_backend: Option<&str>, wayland_display: bool) -> bool {
+    if let Some(list) = gdk_backend {
+        for tok in list.split(',') {
+            match tok.trim().to_ascii_lowercase().as_str() {
+                "x11" => return true,
+                "wayland" => return false,
+                _ => continue,
+            }
+        }
+    }
+    !wayland_display
 }
 
 /// Strip mode is the tab implementation everywhere except macOS.
@@ -768,7 +804,24 @@ pub(crate) fn add_tab_with(app: &AppHandle, window_label: &str, spec: TabSpec) {
             if bounced {
                 log::info!("strip: restored tab {tab2} bounced to root — retrying {deep}");
                 let _ = wv2.navigate(deep);
+                return;
             }
+            // Second #37 shape (the one the v0.6.1 root-bounce retry above
+            // never catches — b3nw still hit it on v0.6.1): the WebUI shows
+            // its "Session not available in web UI." empty state IN PLACE at
+            // the deep route, without bouncing the URL. The session exists —
+            // switching away and back loads it — i.e. the deep link raced the
+            // session index and a re-resolve fixes it. Probe the page once,
+            // ~5s after create, and reload in place if the marker is present
+            // (the exact string rendered by webui sessions.js). One-shot: a
+            // healthy tab never matches and pays nothing.
+            std::thread::sleep(std::time::Duration::from_millis(2500));
+            let _ = wv2.eval(
+                r#"(function(){try{
+                     var t = document.body ? (document.body.innerText || '') : '';
+                     if (t.indexOf('Session not available in web UI.') !== -1) location.reload();
+                   }catch(e){}})();"#,
+            );
         });
     }
 }
@@ -1446,7 +1499,7 @@ pub fn forget_window(app: &AppHandle, window_label: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::partition_suffix;
+    use super::{partition_suffix, x11_from_env};
 
     #[test]
     fn parses_partition_suffix() {
@@ -1456,5 +1509,26 @@ mod tests {
         assert_eq!(partition_suffix("tab-10-0"), Some(0));
         assert_eq!(partition_suffix("garbage"), None);
         assert_eq!(partition_suffix(""), None);
+    }
+
+    #[test]
+    fn x11_detection_mirrors_gdk_backend_choice() {
+        // Issue #80: the physical-coordinate compensation (#67/#68) must apply
+        // ONLY where wry's bogus X11 DPI derivation runs.
+        // Plain X11 session: no wayland display, no override → X11.
+        assert!(x11_from_env(None, false));
+        // Native Wayland session → NOT X11 (compensation off).
+        assert!(!x11_from_env(None, true));
+        // XWayland forced via GDK_BACKEND=x11 → X11 path (compensation ON —
+        // XWayland screens report bogus mm sizes too).
+        assert!(x11_from_env(Some("x11"), true));
+        // Explicit wayland override wins even without WAYLAND_DISPLAY.
+        assert!(!x11_from_env(Some("wayland"), false));
+        // GDK_BACKEND fallback lists.
+        assert!(x11_from_env(Some("x11,wayland"), true));
+        assert!(!x11_from_env(Some("wayland,x11"), true));
+        // Unrelated override (e.g. "broadway") on an X session → default rule.
+        assert!(x11_from_env(Some("broadway"), false));
+        assert!(!x11_from_env(Some("broadway"), true));
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -153,6 +153,7 @@ pub fn forget(app: &AppHandle, label: &str) {
     state.raw_titles.lock().unwrap().remove(label);
     state.window_profiles.lock().unwrap().remove(label);
     state.window_profile_names.lock().unwrap().remove(label);
+    state.window_indicators.lock().unwrap().remove(label);
     crate::session::forget_navigated(app, label);
     crate::session::forget_url(app, label);
 }
@@ -783,7 +784,48 @@ pub fn refresh_title(app: &AppHandle, label: &str) {
         Some(name) if !name.is_empty() => format!("{name} · {base}"),
         _ => base,
     };
+    // State adornment (issues #64/#65), outermost so it's always visible:
+    // "●" = the session is waiting on you (approval/clarify — the page's own
+    // title marker, previously stripped and dropped here); "⟳" = working.
+    // Attention outranks busy: a paused-for-you run matters more than motion.
+    let titled = match state
+        .window_indicators
+        .lock()
+        .unwrap()
+        .get(label)
+        .copied()
+        .unwrap_or((false, false))
+    {
+        (_, true) => format!("● {titled}"),
+        (true, false) => format!("⟳ {titled}"),
+        _ => titled,
+    };
     let _ = w.set_title(&titled);
+}
+
+/// Update a content window's (busy, attention) native-title adornment (issues
+/// #64/#65) — `None` leaves that half unchanged. Repaints only on change.
+pub fn set_window_indicator(
+    app: &AppHandle,
+    label: &str,
+    busy: Option<bool>,
+    attention: Option<bool>,
+) {
+    let changed = {
+        let state = app.state::<AppState>();
+        let mut map = state.window_indicators.lock().unwrap();
+        let cur = map.get(label).copied().unwrap_or((false, false));
+        let next = (busy.unwrap_or(cur.0), attention.unwrap_or(cur.1));
+        if next == cur {
+            false
+        } else {
+            map.insert(label.to_string(), next);
+            true
+        }
+    };
+    if changed {
+        refresh_title(app, label);
+    }
 }
 
 /// Set (or clear, on empty) a content window's active profile NAME, used to
@@ -823,13 +865,16 @@ pub fn apply_reported_title(app: &AppHandle, label: &str, raw: &str) {
     if label.starts_with("tab-") {
         strip::set_tab_title(app, label, title, attention);
     } else {
-        // macOS / regular content windows: no per-tab badge, but store the
-        // marker-free title so the native window title never shows a stray "●".
+        // macOS / regular content windows: store the marker-free title (the
+        // adornment is re-applied in a controlled position by refresh_title)
+        // and keep the attention flag — it used to be dropped here, which is
+        // why macOS never showed needs-attention state (issue #64).
         app.state::<AppState>()
             .raw_titles
             .lock()
             .unwrap()
             .insert(label.to_string(), title.to_string());
+        set_window_indicator(app, label, None, Some(attention));
         refresh_title(app, label);
     }
 }


### PR DESCRIPTION
Nine tracker items in one sweep. Per-issue details in the CHANGELOG entry and commit message; the high-risk items and their verification:

## Fixes

- **#80 Wayland top gap** — the #67/#68 physical-coordinate compensation exists to defeat wry's **X11-only** bogus DPI derivation, but applied on all Linux; on native Wayland it over-corrects into the reported gap. Now gated on GDK actually running X11 (`x11_from_env`, ordered-preference-list semantics incl. XWayland, unit-tested). X11 behavior byte-identical — Linux smoke (X11/Xvfb) re-validates the #67 fix still holds.
- **#51/#81 notification dedupe** — all tabs funnel through the single `"notify"` bridge arm; identical title+body now suppressed within a fixed 30s window (insert-on-show only → a persistent repeater reminds once per window instead of flooding until crash). Pure `dedupe_decide` unit-tested. #81's page-side re-fire root cause on Wayland remains open; this caps the blast radius natively.
- **#74 stale spinner** — background webviews throttle timers, silencing BUSY_REPORTER; the existing 4s native loop now evals `__hermesReportBusy()` into every content webview (evals ignore timer throttling; debounce keeps it emit-on-change).
- **#37 restore probe (round 3)** — the v0.6.1 retry only caught the root-bounce variant; a one-shot in-page probe ~5s post-create now reloads a restored tab showing the webui's exact in-place failure marker (`sessions.js:1862` string).

## Features

- **#64/#65 macOS per-tab state** — native tab titles adorn with ● (attention — previously computed then dropped in `apply_reported_title`) / ⟳ (busy — BUSY_REPORTER now injected on macOS), same mechanism as the #44 profile prefix. Attention outranks busy.
- **#76 Refresh All Tabs** (⋮ menu, mac View menu, Ctrl/Cmd+Shift+R) — one action clears per-tab hard-refresh banners after a WebUI update.
- **#75 click-to-copy version**; **#78 `HERMES_DESKTOP_SAFE_RENDER=1`** (WebKitGTK DMABUF/compositing off before webview init — EGL blank-window recovery; explicit `WEBKIT_*` always wins).

## Verification

- 23 unit tests green (new: GDK backend choice, dedupe window semantics); clippy `-D warnings` clean; `cargo xwin check` clean.
- **Live macOS run** (`HERMES_TEST_TAB_AFTER`): 2 native tab attaches, 8/8 main-thread heartbeats, 3 windows, zero panics — exercises the changed init-script assembly on every mac webview.
- Linux smoke dispatched on this branch (X11 path regression check for #80's gate).
- Field confirmation requested from reporters: digitwo (#80 Wayland, #81 flood), b3nw (#74, #37), miguelangelnieto (#78 flag).

Closes #64
Closes #65
Closes #74
Closes #75
Closes #76
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)